### PR TITLE
Fix the navigation triggering a full page auto scroll

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -32,8 +32,10 @@ export const NavAnchor = forwardRef<
     if (active) {
       internalRef.current?.scrollIntoView({
         behavior: "smooth",
-        block: "start",
         inline: "start",
+        block: "nearest",
+        // @ts-expect-error This isn't in the TS DOM types yet, only supported by Chrome
+        container: "nearest",
       });
     }
   }, [active]);


### PR DESCRIPTION
This was making the page scroll a little bit on load, whereas we're only
interested in horizontal scrolling of the navigation.
