### PR TITLE
Fix the runtime config not being set on initial load

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -18,7 +18,8 @@ server {
 
     # Handle SPA routing
     location / {
-        try_files $uri $uri/ /index.runtime.html /index.html;
+        index /index.runtime.html /index.html;
+        try_files $uri $uri/ /;
     }
 
     # Security headers


### PR DESCRIPTION
This happened because loading `/` would load `/index.html` instead of `/index.runtime.html`, meaning the custom config wouldn't be injected.
