### PR TITLE
Speed up the users and registration tokens lists by loading the total count separately

### DIFF
--- a/src/api/mas/api/sdk.gen.ts
+++ b/src/api/mas/api/sdk.gen.ts
@@ -39,6 +39,9 @@ import type {
   GetUpstreamOAuthLinkData,
   GetUpstreamOAuthLinkErrors,
   GetUpstreamOAuthLinkResponses,
+  GetUpstreamOAuthProviderData,
+  GetUpstreamOAuthProviderErrors,
+  GetUpstreamOAuthProviderResponses,
   GetUserByUsernameData,
   GetUserByUsernameErrors,
   GetUserByUsernameResponses,
@@ -130,6 +133,8 @@ import {
   vGetPolicyDataResponse,
   vGetUpstreamOAuthLinkData,
   vGetUpstreamOAuthLinkResponse,
+  vGetUpstreamOAuthProviderData,
+  vGetUpstreamOAuthProviderResponse,
   vGetUserByUsernameData,
   vGetUserByUsernameResponse,
   vGetUserData,
@@ -1300,6 +1305,36 @@ export const listUpstreamOAuthProviders = <ThrowOnError extends boolean = true>(
       },
     ],
     url: "/api/admin/v1/upstream-oauth-providers",
+    ...options,
+  });
+};
+
+/**
+ * Get upstream OAuth provider
+ */
+export const getUpstreamOAuthProvider = <ThrowOnError extends boolean = true>(
+  options: Options<GetUpstreamOAuthProviderData, ThrowOnError>,
+) => {
+  return options.client.get<
+    GetUpstreamOAuthProviderResponses,
+    GetUpstreamOAuthProviderErrors,
+    ThrowOnError,
+    "data"
+  >({
+    requestValidator: async (data) => {
+      return await v.parseAsync(vGetUpstreamOAuthProviderData, data);
+    },
+    responseValidator: async (data) => {
+      return await v.parseAsync(vGetUpstreamOAuthProviderResponse, data);
+    },
+    responseStyle: "data",
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/api/admin/v1/upstream-oauth-providers/{id}",
     ...options,
   });
 };

--- a/src/api/mas/api/types.gen.ts
+++ b/src/api/mas/api/types.gen.ts
@@ -62,6 +62,7 @@ export type PaginationParams = {
    * Retrieve the last N items
    */
   "page[last]"?: number | null;
+  count?: IncludeCount;
 };
 
 /**
@@ -69,6 +70,8 @@ export type PaginationParams = {
  * A ULID as per https://github.com/ulid/spec
  */
 export type Ulid = string;
+
+export type IncludeCount = "true" | "false" | "only";
 
 export type CompatSessionFilter = {
   "filter[user]"?: Ulid;
@@ -82,11 +85,11 @@ export type CompatSessionStatus = "active" | "finished";
  * A top-level response with a page of resources
  */
 export type PaginatedResponseForCompatSession = {
-  meta: PaginationMeta;
+  meta?: PaginationMeta;
   /**
    * The list of resources
    */
-  data: Array<SingleResourceForCompatSession>;
+  data?: Array<SingleResourceForCompatSession> | null;
   links: PaginationLinks;
 };
 
@@ -94,7 +97,7 @@ export type PaginationMeta = {
   /**
    * The total number of results
    */
-  count: number;
+  count?: number | null;
 };
 
 /**
@@ -108,6 +111,7 @@ export type SingleResourceForCompatSession = {
   id: Ulid;
   attributes: CompatSession;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -163,6 +167,23 @@ export type SelfLinks = {
 };
 
 /**
+ * Metadata associated with a resource
+ */
+export type SingleResourceMeta = {
+  page?: SingleResourceMetaPage;
+};
+
+/**
+ * Pagination metadata for a resource
+ */
+export type SingleResourceMetaPage = {
+  /**
+   * The cursor of this resource in the paginated result
+   */
+  cursor: string;
+};
+
+/**
  * Related links
  */
 export type PaginationLinks = {
@@ -173,11 +194,11 @@ export type PaginationLinks = {
   /**
    * The link to the first page of results
    */
-  first: string;
+  first?: string | null;
   /**
    * The link to the last page of results
    */
-  last: string;
+  last?: string | null;
   /**
    * The link to the next page of results
    *
@@ -244,11 +265,11 @@ export type OAuth2SessionStatus = "active" | "finished";
  * A top-level response with a page of resources
  */
 export type PaginatedResponseForOAuth2Session = {
-  meta: PaginationMeta;
+  meta?: PaginationMeta;
   /**
    * The list of resources
    */
-  data: Array<SingleResourceForOAuth2Session>;
+  data?: Array<SingleResourceForOAuth2Session> | null;
   links: PaginationLinks;
 };
 
@@ -263,6 +284,7 @@ export type SingleResourceForOAuth2Session = {
   id: Ulid;
   attributes: OAuth2Session;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -336,6 +358,7 @@ export type SingleResourceForPolicyData = {
   id: Ulid;
   attributes: PolicyData;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -376,11 +399,11 @@ export type UserStatus = "active" | "locked" | "deactivated";
  * A top-level response with a page of resources
  */
 export type PaginatedResponseForUser = {
-  meta: PaginationMeta;
+  meta?: PaginationMeta;
   /**
    * The list of resources
    */
-  data: Array<SingleResourceForUser>;
+  data?: Array<SingleResourceForUser> | null;
   links: PaginationLinks;
 };
 
@@ -395,6 +418,7 @@ export type SingleResourceForUser = {
   id: Ulid;
   attributes: User;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -504,11 +528,11 @@ export type UserEmailFilter = {
  * A top-level response with a page of resources
  */
 export type PaginatedResponseForUserEmail = {
-  meta: PaginationMeta;
+  meta?: PaginationMeta;
   /**
    * The list of resources
    */
-  data: Array<SingleResourceForUserEmail>;
+  data?: Array<SingleResourceForUserEmail> | null;
   links: PaginationLinks;
 };
 
@@ -523,6 +547,7 @@ export type SingleResourceForUserEmail = {
   id: Ulid;
   attributes: UserEmail;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -570,11 +595,11 @@ export type UserSessionStatus = "active" | "finished";
  * A top-level response with a page of resources
  */
 export type PaginatedResponseForUserSession = {
-  meta: PaginationMeta;
+  meta?: PaginationMeta;
   /**
    * The list of resources
    */
-  data: Array<SingleResourceForUserSession>;
+  data?: Array<SingleResourceForUserSession> | null;
   links: PaginationLinks;
 };
 
@@ -589,6 +614,7 @@ export type SingleResourceForUserSession = {
   id: Ulid;
   attributes: UserSession;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -651,11 +677,11 @@ export type RegistrationTokenFilter = {
  * A top-level response with a page of resources
  */
 export type PaginatedResponseForUserRegistrationToken = {
-  meta: PaginationMeta;
+  meta?: PaginationMeta;
   /**
    * The list of resources
    */
-  data: Array<SingleResourceForUserRegistrationToken>;
+  data?: Array<SingleResourceForUserRegistrationToken> | null;
   links: PaginationLinks;
 };
 
@@ -670,6 +696,7 @@ export type SingleResourceForUserRegistrationToken = {
   id: Ulid;
   attributes: UserRegistrationToken;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -763,11 +790,11 @@ export type UpstreamOAuthLinkFilter = {
  * A top-level response with a page of resources
  */
 export type PaginatedResponseForUpstreamOAuthLink = {
-  meta: PaginationMeta;
+  meta?: PaginationMeta;
   /**
    * The list of resources
    */
-  data: Array<SingleResourceForUpstreamOAuthLink>;
+  data?: Array<SingleResourceForUpstreamOAuthLink> | null;
   links: PaginationLinks;
 };
 
@@ -782,6 +809,7 @@ export type SingleResourceForUpstreamOAuthLink = {
   id: Ulid;
   attributes: UpstreamOAuthLink;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -839,11 +867,11 @@ export type UpstreamOAuthProviderFilter = {
  * A top-level response with a page of resources
  */
 export type PaginatedResponseForUpstreamOAuthProvider = {
-  meta: PaginationMeta;
+  meta?: PaginationMeta;
   /**
    * The list of resources
    */
-  data: Array<SingleResourceForUpstreamOAuthProvider>;
+  data?: Array<SingleResourceForUpstreamOAuthProvider> | null;
   links: PaginationLinks;
 };
 
@@ -858,6 +886,7 @@ export type SingleResourceForUpstreamOAuthProvider = {
   id: Ulid;
   attributes: UpstreamOAuthProvider;
   links: SelfLinks;
+  meta?: SingleResourceMeta;
 };
 
 /**
@@ -884,6 +913,14 @@ export type UpstreamOAuthProvider = {
    * When the provider was disabled. If null, the provider is enabled.
    */
   disabled_at?: string | null;
+};
+
+/**
+ * A top-level response with a single resource
+ */
+export type SingleResponseForUpstreamOAuthProvider = {
+  data: SingleResourceForUpstreamOAuthProvider;
+  links: SelfLinks;
 };
 
 export type SiteConfigData = {
@@ -919,6 +956,10 @@ export type ListCompatSessionsData = {
      * Retrieve the last N items
      */
     "page[last]"?: number | null;
+    /**
+     * Include the total number of items. Defaults to `true`.
+     */
+    count?: IncludeCount;
     /**
      * Retrieve the items for the given user
      */
@@ -1010,6 +1051,10 @@ export type ListOAuth2SessionsData = {
      * Retrieve the last N items
      */
     "page[last]"?: number | null;
+    /**
+     * Include the total number of items. Defaults to `true`.
+     */
+    count?: IncludeCount;
     /**
      * Retrieve the items for the given user
      */
@@ -1198,6 +1243,10 @@ export type ListUsersData = {
      * Retrieve the last N items
      */
     "page[last]"?: number | null;
+    /**
+     * Include the total number of items. Defaults to `true`.
+     */
+    count?: IncludeCount;
     /**
      * Retrieve users with (or without) the `admin` flag set
      */
@@ -1523,6 +1572,10 @@ export type ListUserEmailsData = {
      */
     "page[last]"?: number | null;
     /**
+     * Include the total number of items. Defaults to `true`.
+     */
+    count?: IncludeCount;
+    /**
      * Retrieve the items for the given user
      */
     "filter[user]"?: Ulid;
@@ -1666,6 +1719,10 @@ export type ListUserSessionsData = {
      */
     "page[last]"?: number | null;
     /**
+     * Include the total number of items. Defaults to `true`.
+     */
+    count?: IncludeCount;
+    /**
      * Retrieve the items for the given user
      */
     "filter[user]"?: Ulid;
@@ -1752,6 +1809,10 @@ export type ListUserRegistrationTokensData = {
      * Retrieve the last N items
      */
     "page[last]"?: number | null;
+    /**
+     * Include the total number of items. Defaults to `true`.
+     */
+    count?: IncludeCount;
     /**
      * Retrieve tokens that have (or have not) been used at least once
      */
@@ -1946,6 +2007,10 @@ export type ListUpstreamOAuthLinksData = {
      */
     "page[last]"?: number | null;
     /**
+     * Include the total number of items. Defaults to `true`.
+     */
+    count?: IncludeCount;
+    /**
      * Retrieve the items for the given user
      */
     "filter[user]"?: Ulid;
@@ -2095,6 +2160,10 @@ export type ListUpstreamOAuthProvidersData = {
      */
     "page[last]"?: number | null;
     /**
+     * Include the total number of items. Defaults to `true`.
+     */
+    count?: IncludeCount;
+    /**
      * Retrieve providers that are (or are not) enabled
      */
     "filter[enabled]"?: boolean | null;
@@ -2111,3 +2180,32 @@ export type ListUpstreamOAuthProvidersResponses = {
 
 export type ListUpstreamOAuthProvidersResponse =
   ListUpstreamOAuthProvidersResponses[keyof ListUpstreamOAuthProvidersResponses];
+
+export type GetUpstreamOAuthProviderData = {
+  body?: never;
+  path: {
+    id: Ulid;
+  };
+  query?: never;
+  url: "/api/admin/v1/upstream-oauth-providers/{id}";
+};
+
+export type GetUpstreamOAuthProviderErrors = {
+  /**
+   * Provider not found
+   */
+  404: ErrorResponse;
+};
+
+export type GetUpstreamOAuthProviderError =
+  GetUpstreamOAuthProviderErrors[keyof GetUpstreamOAuthProviderErrors];
+
+export type GetUpstreamOAuthProviderResponses = {
+  /**
+   * The upstream OAuth provider
+   */
+  200: SingleResponseForUpstreamOAuthProvider;
+};
+
+export type GetUpstreamOAuthProviderResponse =
+  GetUpstreamOAuthProviderResponses[keyof GetUpstreamOAuthProviderResponses];

--- a/src/api/mas/api/valibot.gen.ts
+++ b/src/api/mas/api/valibot.gen.ts
@@ -32,6 +32,12 @@ export const vUlid = v.pipe(
   v.regex(/^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/),
 );
 
+export const vIncludeCount = v.union([
+  v.picklist(["true"]),
+  v.picklist(["false"]),
+  v.picklist(["only"]),
+]);
+
 export const vPaginationParams = v.object({
   "page[before]": v.optional(vUlid),
   "page[after]": v.optional(vUlid),
@@ -41,6 +47,7 @@ export const vPaginationParams = v.object({
   "page[last]": v.optional(
     v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
   ),
+  count: v.optional(vIncludeCount),
 });
 
 export const vCompatSessionStatus = v.picklist(["active", "finished"]);
@@ -52,7 +59,9 @@ export const vCompatSessionFilter = v.object({
 });
 
 export const vPaginationMeta = v.object({
-  count: v.pipe(v.number(), v.integer(), v.minValue(0)),
+  count: v.optional(
+    v.union([v.pipe(v.number(), v.integer(), v.minValue(0)), v.null()]),
+  ),
 });
 
 /**
@@ -91,6 +100,20 @@ export const vSelfLinks = v.object({
 });
 
 /**
+ * Pagination metadata for a resource
+ */
+export const vSingleResourceMetaPage = v.object({
+  cursor: v.string(),
+});
+
+/**
+ * Metadata associated with a resource
+ */
+export const vSingleResourceMeta = v.object({
+  page: v.optional(vSingleResourceMetaPage),
+});
+
+/**
  * A single resource, with its type, ID, attributes and related links
  */
 export const vSingleResourceForCompatSession = v.object({
@@ -98,6 +121,7 @@ export const vSingleResourceForCompatSession = v.object({
   id: vUlid,
   attributes: vCompatSession,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
@@ -105,8 +129,8 @@ export const vSingleResourceForCompatSession = v.object({
  */
 export const vPaginationLinks = v.object({
   self: v.string(),
-  first: v.string(),
-  last: v.string(),
+  first: v.optional(v.union([v.string(), v.null()])),
+  last: v.optional(v.union([v.string(), v.null()])),
   next: v.optional(v.union([v.string(), v.null()])),
   prev: v.optional(v.union([v.string(), v.null()])),
 });
@@ -115,8 +139,10 @@ export const vPaginationLinks = v.object({
  * A top-level response with a page of resources
  */
 export const vPaginatedResponseForCompatSession = v.object({
-  meta: vPaginationMeta,
-  data: v.array(vSingleResourceForCompatSession),
+  meta: v.optional(vPaginationMeta),
+  data: v.optional(
+    v.union([v.array(vSingleResourceForCompatSession), v.null()]),
+  ),
   links: vPaginationLinks,
 });
 
@@ -187,14 +213,17 @@ export const vSingleResourceForOAuth2Session = v.object({
   id: vUlid,
   attributes: vOAuth2Session,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
  * A top-level response with a page of resources
  */
 export const vPaginatedResponseForOAuth2Session = v.object({
-  meta: vPaginationMeta,
-  data: v.array(vSingleResourceForOAuth2Session),
+  meta: v.optional(vPaginationMeta),
+  data: v.optional(
+    v.union([v.array(vSingleResourceForOAuth2Session), v.null()]),
+  ),
   links: vPaginationLinks,
 });
 
@@ -229,6 +258,7 @@ export const vSingleResourceForPolicyData = v.object({
   id: vUlid,
   attributes: vPolicyData,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
@@ -272,14 +302,15 @@ export const vSingleResourceForUser = v.object({
   id: vUlid,
   attributes: vUser,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
  * A top-level response with a page of resources
  */
 export const vPaginatedResponseForUser = v.object({
-  meta: vPaginationMeta,
-  data: v.array(vSingleResourceForUser),
+  meta: v.optional(vPaginationMeta),
+  data: v.optional(v.union([v.array(vSingleResourceForUser), v.null()])),
   links: vPaginationLinks,
 });
 
@@ -347,14 +378,15 @@ export const vSingleResourceForUserEmail = v.object({
   id: vUlid,
   attributes: vUserEmail,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
  * A top-level response with a page of resources
  */
 export const vPaginatedResponseForUserEmail = v.object({
-  meta: vPaginationMeta,
-  data: v.array(vSingleResourceForUserEmail),
+  meta: v.optional(vPaginationMeta),
+  data: v.optional(v.union([v.array(vSingleResourceForUserEmail), v.null()])),
   links: vPaginationLinks,
 });
 
@@ -405,14 +437,15 @@ export const vSingleResourceForUserSession = v.object({
   id: vUlid,
   attributes: vUserSession,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
  * A top-level response with a page of resources
  */
 export const vPaginatedResponseForUserSession = v.object({
-  meta: vPaginationMeta,
-  data: v.array(vSingleResourceForUserSession),
+  meta: v.optional(vPaginationMeta),
+  data: v.optional(v.union([v.array(vSingleResourceForUserSession), v.null()])),
   links: vPaginationLinks,
 });
 
@@ -479,14 +512,17 @@ export const vSingleResourceForUserRegistrationToken = v.object({
   id: vUlid,
   attributes: vUserRegistrationToken,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
  * A top-level response with a page of resources
  */
 export const vPaginatedResponseForUserRegistrationToken = v.object({
-  meta: vPaginationMeta,
-  data: v.array(vSingleResourceForUserRegistrationToken),
+  meta: v.optional(vPaginationMeta),
+  data: v.optional(
+    v.union([v.array(vSingleResourceForUserRegistrationToken), v.null()]),
+  ),
   links: vPaginationLinks,
 });
 
@@ -572,14 +608,17 @@ export const vSingleResourceForUpstreamOAuthLink = v.object({
   id: vUlid,
   attributes: vUpstreamOAuthLink,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
  * A top-level response with a page of resources
  */
 export const vPaginatedResponseForUpstreamOAuthLink = v.object({
-  meta: vPaginationMeta,
-  data: v.array(vSingleResourceForUpstreamOAuthLink),
+  meta: v.optional(vPaginationMeta),
+  data: v.optional(
+    v.union([v.array(vSingleResourceForUpstreamOAuthLink), v.null()]),
+  ),
   links: vPaginationLinks,
 });
 
@@ -626,15 +665,26 @@ export const vSingleResourceForUpstreamOAuthProvider = v.object({
   id: vUlid,
   attributes: vUpstreamOAuthProvider,
   links: vSelfLinks,
+  meta: v.optional(vSingleResourceMeta),
 });
 
 /**
  * A top-level response with a page of resources
  */
 export const vPaginatedResponseForUpstreamOAuthProvider = v.object({
-  meta: vPaginationMeta,
-  data: v.array(vSingleResourceForUpstreamOAuthProvider),
+  meta: v.optional(vPaginationMeta),
+  data: v.optional(
+    v.union([v.array(vSingleResourceForUpstreamOAuthProvider), v.null()]),
+  ),
   links: vPaginationLinks,
+});
+
+/**
+ * A top-level response with a single resource
+ */
+export const vSingleResponseForUpstreamOAuthProvider = v.object({
+  data: vSingleResourceForUpstreamOAuthProvider,
+  links: vSelfLinks,
 });
 
 export const vSiteConfigData = v.object({
@@ -658,6 +708,7 @@ export const vListCompatSessionsData = v.object({
       "page[last]": v.optional(
         v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
       ),
+      count: v.optional(vIncludeCount),
       "filter[user]": v.optional(vUlid),
       "filter[user-session]": v.optional(vUlid),
       "filter[status]": v.optional(vCompatSessionStatus),
@@ -696,6 +747,7 @@ export const vListOAuth2SessionsData = v.object({
       "page[last]": v.optional(
         v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
       ),
+      count: v.optional(vIncludeCount),
       "filter[user]": v.optional(vUlid),
       "filter[client]": v.optional(vUlid),
       "filter[client-kind]": v.optional(vOAuth2ClientKind),
@@ -772,6 +824,7 @@ export const vListUsersData = v.object({
       "page[last]": v.optional(
         v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
       ),
+      count: v.optional(vIncludeCount),
       "filter[admin]": v.optional(v.union([v.boolean(), v.null()])),
       "filter[legacy-guest]": v.optional(v.union([v.boolean(), v.null()])),
       "filter[search]": v.optional(v.union([v.string(), v.null()])),
@@ -913,6 +966,7 @@ export const vListUserEmailsData = v.object({
       "page[last]": v.optional(
         v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
       ),
+      count: v.optional(vIncludeCount),
       "filter[user]": v.optional(vUlid),
       "filter[email]": v.optional(v.union([v.string(), v.null()])),
     }),
@@ -974,6 +1028,7 @@ export const vListUserSessionsData = v.object({
       "page[last]": v.optional(
         v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
       ),
+      count: v.optional(vIncludeCount),
       "filter[user]": v.optional(vUlid),
       "filter[status]": v.optional(vUserSessionStatus),
     }),
@@ -1011,6 +1066,7 @@ export const vListUserRegistrationTokensData = v.object({
       "page[last]": v.optional(
         v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
       ),
+      count: v.optional(vIncludeCount),
       "filter[used]": v.optional(v.union([v.boolean(), v.null()])),
       "filter[revoked]": v.optional(v.union([v.boolean(), v.null()])),
       "filter[expired]": v.optional(v.union([v.boolean(), v.null()])),
@@ -1106,6 +1162,7 @@ export const vListUpstreamOAuthLinksData = v.object({
       "page[last]": v.optional(
         v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
       ),
+      count: v.optional(vIncludeCount),
       "filter[user]": v.optional(vUlid),
       "filter[provider]": v.optional(vUlid),
       "filter[subject]": v.optional(v.union([v.string(), v.null()])),
@@ -1171,6 +1228,7 @@ export const vListUpstreamOAuthProvidersData = v.object({
       "page[last]": v.optional(
         v.union([v.pipe(v.number(), v.integer(), v.minValue(1)), v.null()]),
       ),
+      count: v.optional(vIncludeCount),
       "filter[enabled]": v.optional(v.union([v.boolean(), v.null()])),
     }),
   ),
@@ -1181,3 +1239,17 @@ export const vListUpstreamOAuthProvidersData = v.object({
  */
 export const vListUpstreamOAuthProvidersResponse =
   vPaginatedResponseForUpstreamOAuthProvider;
+
+export const vGetUpstreamOAuthProviderData = v.object({
+  body: v.optional(v.never()),
+  path: v.object({
+    id: vUlid,
+  }),
+  query: v.optional(v.never()),
+});
+
+/**
+ * The upstream OAuth provider
+ */
+export const vGetUpstreamOAuthProviderResponse =
+  vSingleResponseForUpstreamOAuthProvider;

--- a/src/api/mas/index.ts
+++ b/src/api/mas/index.ts
@@ -24,6 +24,37 @@ const masClient = createClient({
 export const isErrorResponse = (t: unknown): t is api.ErrorResponse =>
   typeof t === "object" && t !== null && Object.hasOwn(t, "errors");
 
+function ensureHasData<R extends { data?: unknown[] | null | undefined }>(
+  response: R,
+): asserts response is R & { data: NonNullable<R["data"]> } {
+  if (!Array.isArray(response?.data)) {
+    throw new TypeError("Unexpected response from MAS");
+  }
+}
+
+function ensureHasCount<R extends { meta?: { count?: number | null } | null }>(
+  response: R,
+): asserts response is R & { meta: { count: number } } {
+  if (typeof response.meta?.count !== "number") {
+    throw new TypeError("Unexpected response from MAS");
+  }
+}
+
+interface SingleResource {
+  readonly id: string;
+  readonly meta?: {
+    readonly page?: {
+      cursor: string;
+    };
+  };
+}
+
+// Extracts the cursor from an item on a page. This works with both MAS 1.4.0
+// and earlier versions
+const cursorForSingleResource = (
+  resource: SingleResource | null | undefined,
+): string | null => resource?.meta?.page?.cursor ?? resource?.id ?? null;
+
 const masBaseOptions = async (
   client: QueryClient,
   serverName: string,
@@ -137,7 +168,9 @@ export const usersInfiniteQuery = (
   infiniteQueryOptions({
     queryKey: ["mas", "users", serverName, parameters, direction],
     queryFn: async ({ client, signal, pageParam }) => {
-      const query: api.ListUsersData["query"] = {};
+      const query: api.ListUsersData["query"] = {
+        count: "false",
+      };
 
       if (direction === "forward") {
         query["page[first]"] = PAGE_SIZE;
@@ -154,16 +187,20 @@ export const usersInfiniteQuery = (
       if (parameters.status) query["filter[status]"] = parameters.status;
       if (parameters.search) query["filter[search]"] = parameters.search;
 
-      return await api.listUsers({
+      const response = await api.listUsers({
         ...(await masBaseOptions(client, serverName, signal)),
         query,
       });
+      ensureHasData(response);
+
+      return response;
     },
-    initialPageParam: null as api.Ulid | null,
-    getNextPageParam: (lastPage): api.Ulid | null =>
-      direction === "forward"
-        ? ((lastPage.links.next && lastPage.data.at(-1)?.id) ?? null)
-        : ((lastPage.links.prev && lastPage.data.at(0)?.id) ?? null),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage): string | null =>
+      (direction === "forward"
+        ? lastPage.links.next && cursorForSingleResource(lastPage.data?.at(-1))
+        : lastPage.links.prev &&
+          cursorForSingleResource(lastPage.data?.at(0))) ?? null,
   });
 
 export const userQuery = (serverName: string, userId: string) =>
@@ -184,9 +221,11 @@ export const registeredUsersCountQuery = (serverName: string) =>
       const data = await api.listUsers({
         ...(await masBaseOptions(client, serverName, signal)),
         query: {
-          "page[first]": 1,
+          count: "only",
         },
       });
+      ensureHasCount(data);
+
       return data.meta.count;
     },
   });
@@ -279,13 +318,15 @@ export const userEmailsQuery = (serverName: string, userId: string) =>
   queryOptions({
     queryKey: ["mas", "user-emails", serverName, userId],
     queryFn: async ({ client, signal }) => {
-      return await api.listUserEmails({
+      const response = await api.listUserEmails({
         ...(await masBaseOptions(client, serverName, signal)),
         query: {
           "filter[user]": userId,
           "page[first]": 10,
         },
       });
+      ensureHasData(response);
+      return response;
     },
   });
 
@@ -321,13 +362,16 @@ export const userUpstreamLinksQuery = (serverName: string, userId: string) =>
   queryOptions({
     queryKey: ["mas", "user-upstream-links", serverName, userId],
     queryFn: async ({ client, signal }) => {
-      return await api.listUpstreamOAuthLinks({
+      const response = await api.listUpstreamOAuthLinks({
         ...(await masBaseOptions(client, serverName, signal)),
         query: {
           "filter[user]": userId,
           "page[first]": 10,
+          count: "false",
         },
       });
+      ensureHasData(response);
+      return response;
     },
   });
 
@@ -340,8 +384,10 @@ export const upstreamProvidersQuery = (serverName: string) =>
         query: {
           // Let's assume we're not going to have more than 1000 providers
           "page[first]": 1000,
+          count: "false",
         },
       });
+      ensureHasData(response);
       return response.data;
     },
   });
@@ -400,6 +446,7 @@ export const registrationTokensInfiniteQuery = (
     queryFn: async ({ client, signal, pageParam }) => {
       const query: api.ListUserRegistrationTokensData["query"] = {
         "page[first]": PAGE_SIZE,
+        count: "false",
       };
 
       if (pageParam) query["page[after]"] = pageParam;
@@ -413,14 +460,17 @@ export const registrationTokensInfiniteQuery = (
       if (parameters.valid !== undefined)
         query["filter[valid]"] = parameters.valid;
 
-      return await api.listUserRegistrationTokens({
+      const response = await api.listUserRegistrationTokens({
         ...(await masBaseOptions(client, serverName, signal)),
         query,
       });
+      ensureHasData(response);
+      return response;
     },
     initialPageParam: null as api.Ulid | null,
     getNextPageParam: (lastPage): api.Ulid | null =>
-      (lastPage.links.next && lastPage.data.at(-1)?.id) ?? null,
+      (lastPage.links.next && cursorForSingleResource(lastPage.data?.at(-1))) ??
+      null,
   });
 
 export const registrationTokenQuery = (serverName: string, tokenId: string) =>

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -19,6 +19,7 @@ import cx from "classnames";
 import {
   forwardRef,
   Fragment,
+  Suspense,
   useEffect,
   useId,
   useRef,
@@ -26,6 +27,7 @@ import {
 } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import * as Placeholder from "@/components/placeholder";
 import * as messages from "@/messages";
 
 import styles from "./table.module.css";
@@ -51,6 +53,13 @@ export const Title = ({ className, children, ...props }: TitleProps) => (
   <div className={cx(styles["header-title"], className)} {...props}>
     {children}
   </div>
+);
+
+// A table title with a suspense fallback, useful when loading expensive counts in the table title
+export const DynamicTitle = ({ children, ...props }: TitleProps) => (
+  <Title {...props}>
+    <Suspense fallback={<Placeholder.Text />}>{children}</Suspense>
+  </Title>
 );
 
 type FilterMenuProps = React.PropsWithChildren;

--- a/src/routes/_console.index.tsx
+++ b/src/routes/_console.index.tsx
@@ -9,7 +9,7 @@ import { defineMessage, FormattedMessage } from "react-intl";
 
 import { useEssVersion } from "@/api/ess";
 import { githubReleaseQuery } from "@/api/github";
-import { registeredUsersCountQuery } from "@/api/mas";
+import { usersCountQuery } from "@/api/mas";
 import { wellKnownQuery } from "@/api/matrix";
 import { roomsCountQuery, serverVersionQuery } from "@/api/synapse";
 import * as Data from "@/components/data";
@@ -45,9 +45,7 @@ export const Route = createFileRoute("/_console/")({
     // Kick the loading of the 4 queries but don't await them
     queryClient.prefetchQuery(serverVersionQuery(synapseRoot));
     queryClient.prefetchQuery(roomsCountQuery(synapseRoot));
-    queryClient.prefetchQuery(
-      registeredUsersCountQuery(credentials.serverName),
-    );
+    queryClient.prefetchQuery(usersCountQuery(credentials.serverName));
     queryClient.prefetchQuery(latestEssReleaseQuery);
   },
   component: RouteComponent,
@@ -105,7 +103,7 @@ interface RegisteredUsersProps {
 const RegisteredUsers: React.FC<RegisteredUsersProps> = ({
   serverName,
 }: RegisteredUsersProps) => {
-  const { data } = useSuspenseQuery(registeredUsersCountQuery(serverName));
+  const { data } = useSuspenseQuery(usersCountQuery(serverName));
   return <Data.NumericValue value={data} />;
 };
 

--- a/src/routes/_console.registration-tokens.tsx
+++ b/src/routes/_console.registration-tokens.tsx
@@ -531,7 +531,7 @@ function RouteComponent() {
     [data],
   );
 
-  const totalCount = data.pages[0]?.meta.count ?? 0;
+  const totalCount = data.pages[0]?.meta?.count ?? 0;
 
   const filters = useFilters(search, filtersDefinition);
 

--- a/src/routes/_console.users.tsx
+++ b/src/routes/_console.users.tsx
@@ -430,7 +430,7 @@ function RouteComponent() {
     [data, isBackward],
   );
 
-  const totalCount = data.pages[0]?.meta.count ?? 0;
+  const totalCount = data.pages[0]?.meta?.count ?? 0;
 
   const debouncedSearch = useDebouncedCallback(
     (term: string) => {

--- a/src/routes/_console.users.tsx
+++ b/src/routes/_console.users.tsx
@@ -28,7 +28,12 @@ import { toast } from "react-hot-toast";
 import { defineMessage, FormattedMessage, useIntl } from "react-intl";
 import * as v from "valibot";
 
-import { createUser, isErrorResponse, usersInfiniteQuery } from "@/api/mas";
+import {
+  createUser,
+  isErrorResponse,
+  usersCountQuery,
+  usersInfiniteQuery,
+} from "@/api/mas";
 import type { UserListFilters } from "@/api/mas";
 import type { SingleResourceForUser } from "@/api/mas/api/types.gen";
 import {
@@ -89,6 +94,11 @@ export const Route = createFileRoute("/_console/users")({
 
     await queryClient.ensureInfiniteQueryData(
       usersInfiniteQuery(credentials.serverName, parameters, direction),
+    );
+
+    // Kick-off the users count query without awaiting it
+    queryClient.prefetchQuery(
+      usersCountQuery(credentials.serverName, parameters),
     );
   },
 
@@ -334,6 +344,22 @@ const UserAddButton: React.FC<UserAddButtonProps> = ({
   );
 };
 
+const UserCount = ({ serverName }: { serverName: string }) => {
+  const { parameters } = Route.useLoaderDeps();
+  const { data: totalCount } = useSuspenseQuery(
+    usersCountQuery(serverName, parameters),
+  );
+
+  return (
+    <FormattedMessage
+      id="pages.users.user_count"
+      defaultMessage="{COUNT, plural, zero {No users} one {# user} other {# users}}"
+      description="On the user list page, this heading shows the total number of users"
+      values={{ COUNT: totalCount }}
+    />
+  );
+};
+
 const filtersDefinition = [
   {
     key: "dir",
@@ -429,8 +455,6 @@ function RouteComponent() {
       ) ?? [],
     [data, isBackward],
   );
-
-  const totalCount = data.pages[0]?.meta?.count ?? 0;
 
   const debouncedSearch = useDebouncedCallback(
     (term: string) => {
@@ -553,14 +577,9 @@ function RouteComponent() {
 
           <Table.Root>
             <Table.Header>
-              <Table.Title>
-                <FormattedMessage
-                  id="pages.users.user_count"
-                  defaultMessage="{COUNT, plural, zero {No users} one {# user} other {# users}}"
-                  description="On the user list page, this heading shows the total number of users"
-                  values={{ COUNT: totalCount }}
-                />
-              </Table.Title>
+              <Table.DynamicTitle>
+                <UserCount serverName={credentials.serverName} />
+              </Table.DynamicTitle>
 
               <Table.FilterMenu>
                 {filters.all.map((filter) => (


### PR DESCRIPTION
This uses new APIs introduced in MAS 1.4.0 to ask for the list counts separately from the list itself.
This avoids expensive `COUNT(*)` queries on each page of a large list, but rather loads it once, separately from the list items themselves.
