### PR TITLE
Use authenticated media endpoints for thumbnails

### DIFF
--- a/src/api/matrix.ts
+++ b/src/api/matrix.ts
@@ -128,7 +128,7 @@ export const mediaThumbnailQuery = (
       const [serverName, mediaId] = parseMxcUrl(mxc);
 
       const mediaUrl = new URL(
-        `/_matrix/media/v3/thumbnail/${encodeURIComponent(serverName)}/${encodeURIComponent(mediaId)}?width=96&height=96&method=crop`,
+        `/_matrix/client/v1/media/thumbnail/${encodeURIComponent(serverName)}/${encodeURIComponent(mediaId)}?width=96&height=96&method=crop`,
         synapseRoot,
       );
       const response = await fetch(mediaUrl, await baseOptions(client, signal));


### PR DESCRIPTION
Don't know how I missed this, I took care of sending the media request authenticated, save it as blob, but then used the legacy media endpoints…

Fixes #112
