### PR TITLE
Fix the ESS version not loading after a refresh

### DIFF
--- a/src/api/ess.ts
+++ b/src/api/ess.ts
@@ -11,15 +11,7 @@ import { accessToken } from "@/stores/auth";
 import { ensureResponseOk, fetch } from "@/utils/fetch";
 
 const VersionResponse = v.object({
-  version: v.fallback(
-    v.nullable(
-      v.pipe(
-        v.string(),
-        v.transform((version) => parseSemver(version, true, false)),
-      ),
-    ),
-    null,
-  ),
+  version: v.nullable(v.string()),
   edition: v.fallback(v.nullable(v.picklist(["community", "pro"])), null),
 });
 
@@ -64,5 +56,6 @@ export const useEssVariant = (
 
 export const useEssVersion = (synapseRoot: string): null | SemVer => {
   const { data } = useSuspenseQuery(essVersionQuery(synapseRoot));
-  return data?.version;
+  if (!data) return null;
+  return parseSemver(data.version);
 };

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
 import { queryOptions } from "@tanstack/react-query";
-import parseSemver from "semver/functions/parse";
 import * as v from "valibot";
 
 import { ensureResponseOk, fetch } from "@/utils/fetch";
@@ -11,12 +10,7 @@ import { ensureResponseOk, fetch } from "@/utils/fetch";
 const ReleaseResponse = v.object({
   html_url: v.string(),
   name: v.string(),
-  // XXX: this parses the version from the tag as semver; maybe we want to do
-  // that in a separate field?
-  tag_name: v.pipe(
-    v.string(),
-    v.transform((version) => parseSemver(version, true, false)),
-  ),
+  tag_name: v.string(),
   created_at: v.pipe(v.string(), v.isoTimestamp()),
   body: v.string(),
 });


### PR DESCRIPTION
Because we started saving query responses in IndexedDB, sometimes we returned classes, which wouldn't get persisted correctly. This meant that the dashboard wouldn't load after a page refresh