### PR TITLE
Fix links to help and support portal

### DIFF
--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -57,11 +57,11 @@ function RouteComponent() {
           <Footer.Divider />
 
           <Footer.Section>
-            <Link href="https://ems.element.io/support" size="small">
+            <Link href="https://customer.element.io/support" size="small">
               <FormattedMessage
                 id="footer.help_and_support"
                 defaultMessage="Help & Support"
-                description="Label for the help and support (to https://ems.element.io/support) link in the footer"
+                description="Label for the help and support (to https://customer.element.io/support) link in the footer"
               />
             </Link>
             <Footer.Divider />

--- a/src/ui/footer.tsx
+++ b/src/ui/footer.tsx
@@ -13,11 +13,11 @@ const AppFooter = () => (
     <Footer.ElementLogo />
 
     <Footer.Section>
-      <Link href="https://ems.element.io/support" size="small">
+      <Link href="https://customer.element.io/support" size="small">
         <FormattedMessage
           id="footer.help_and_support"
           defaultMessage="Help & Support"
-          description="Label for the help and support (to https://ems.element.io/support) link in the footer"
+          description="Label for the help and support (to https://customer.element.io/support) link in the footer"
         />
       </Link>
       <Footer.Divider />

--- a/translations/extracted/en.json
+++ b/translations/extracted/en.json
@@ -64,7 +64,7 @@
     "message": "Copyright © {now, date, ::yyyy}"
   },
   "footer.help_and_support": {
-    "description": "Label for the help and support (to https://ems.element.io/support) link in the footer",
+    "description": "Label for the help and support (to https://customer.element.io/support) link in the footer",
     "message": "Help & Support"
   },
   "footer.legal": {


### PR DESCRIPTION
Domain changed from `ems.element.io` to `customer.element.io`.