### PR TITLE
Show the auditing ESS Pro feature

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as ConsoleRoomsRouteImport } from './routes/_console.rooms'
 import { Route as ConsoleRegistrationTokensRouteImport } from './routes/_console.registration-tokens'
 import { Route as ConsolePersonalTokensRouteImport } from './routes/_console.personal-tokens'
 import { Route as ConsoleModerationRouteImport } from './routes/_console.moderation'
+import { Route as ConsoleAuditingRouteImport } from './routes/_console.auditing'
 import { Route as AuthLoginIndexRouteImport } from './routes/_auth.login.index'
 import { Route as ConsoleUsersUserIdRouteImport } from './routes/_console.users.$userId'
 import { Route as ConsoleRoomsRoomIdRouteImport } from './routes/_console.rooms.$roomId'
@@ -68,6 +69,11 @@ const ConsoleModerationRoute = ConsoleModerationRouteImport.update({
   path: '/moderation',
   getParentRoute: () => ConsoleRoute,
 } as any)
+const ConsoleAuditingRoute = ConsoleAuditingRouteImport.update({
+  id: '/auditing',
+  path: '/auditing',
+  getParentRoute: () => ConsoleRoute,
+} as any)
 const AuthLoginIndexRoute = AuthLoginIndexRouteImport.update({
   id: '/login/',
   path: '/login/',
@@ -98,6 +104,7 @@ const ConsolePersonalTokensTokenIdRoute =
 
 export interface FileRoutesByFullPath {
   '/callback': typeof CallbackRoute
+  '/auditing': typeof ConsoleAuditingRoute
   '/moderation': typeof ConsoleModerationRoute
   '/personal-tokens': typeof ConsolePersonalTokensRouteWithChildren
   '/registration-tokens': typeof ConsoleRegistrationTokensRouteWithChildren
@@ -112,6 +119,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/callback': typeof CallbackRoute
+  '/auditing': typeof ConsoleAuditingRoute
   '/moderation': typeof ConsoleModerationRoute
   '/personal-tokens': typeof ConsolePersonalTokensRouteWithChildren
   '/registration-tokens': typeof ConsoleRegistrationTokensRouteWithChildren
@@ -129,6 +137,7 @@ export interface FileRoutesById {
   '/_auth': typeof AuthRouteWithChildren
   '/_console': typeof ConsoleRouteWithChildren
   '/callback': typeof CallbackRoute
+  '/_console/auditing': typeof ConsoleAuditingRoute
   '/_console/moderation': typeof ConsoleModerationRoute
   '/_console/personal-tokens': typeof ConsolePersonalTokensRouteWithChildren
   '/_console/registration-tokens': typeof ConsoleRegistrationTokensRouteWithChildren
@@ -145,6 +154,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/callback'
+    | '/auditing'
     | '/moderation'
     | '/personal-tokens'
     | '/registration-tokens'
@@ -159,6 +169,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/callback'
+    | '/auditing'
     | '/moderation'
     | '/personal-tokens'
     | '/registration-tokens'
@@ -175,6 +186,7 @@ export interface FileRouteTypes {
     | '/_auth'
     | '/_console'
     | '/callback'
+    | '/_console/auditing'
     | '/_console/moderation'
     | '/_console/personal-tokens'
     | '/_console/registration-tokens'
@@ -257,6 +269,13 @@ declare module '@tanstack/react-router' {
       path: '/moderation'
       fullPath: '/moderation'
       preLoaderRoute: typeof ConsoleModerationRouteImport
+      parentRoute: typeof ConsoleRoute
+    }
+    '/_console/auditing': {
+      id: '/_console/auditing'
+      path: '/auditing'
+      fullPath: '/auditing'
+      preLoaderRoute: typeof ConsoleAuditingRouteImport
       parentRoute: typeof ConsoleRoute
     }
     '/_auth/login/': {
@@ -360,6 +379,7 @@ const ConsoleUsersRouteWithChildren = ConsoleUsersRoute._addFileChildren(
 )
 
 interface ConsoleRouteChildren {
+  ConsoleAuditingRoute: typeof ConsoleAuditingRoute
   ConsoleModerationRoute: typeof ConsoleModerationRoute
   ConsolePersonalTokensRoute: typeof ConsolePersonalTokensRouteWithChildren
   ConsoleRegistrationTokensRoute: typeof ConsoleRegistrationTokensRouteWithChildren
@@ -369,6 +389,7 @@ interface ConsoleRouteChildren {
 }
 
 const ConsoleRouteChildren: ConsoleRouteChildren = {
+  ConsoleAuditingRoute: ConsoleAuditingRoute,
   ConsoleModerationRoute: ConsoleModerationRoute,
   ConsolePersonalTokensRoute: ConsolePersonalTokensRouteWithChildren,
   ConsoleRegistrationTokensRoute: ConsoleRegistrationTokensRouteWithChildren,

--- a/src/routes/_console.auditing.tsx
+++ b/src/routes/_console.auditing.tsx
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright 2025 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { Alert } from "@vector-im/compound-web";
+import { defineMessage, FormattedMessage, useIntl } from "react-intl";
+
+import { essVersionQuery, useEssVariant } from "@/api/ess";
+import { wellKnownQuery } from "@/api/matrix";
+import * as Card from "@/components/card";
+import * as Navigation from "@/components/navigation";
+import AppFooter from "@/ui/footer";
+import * as Marketing from "@/ui/marketing";
+
+const titleMessage = defineMessage({
+  id: "pages.auditing.title",
+  defaultMessage: "Auditing",
+  description: "The title of the auditing page",
+});
+
+export const Route = createFileRoute("/_console/auditing")({
+  staticData: {
+    breadcrumb: {
+      message: titleMessage,
+    },
+  },
+
+  loader: async ({ context: { queryClient, credentials } }): Promise<void> => {
+    const wellKnown = await queryClient.ensureQueryData(
+      wellKnownQuery(credentials.serverName),
+    );
+    const synapseRoot = wellKnown["m.homeserver"].base_url;
+    await queryClient.ensureQueryData(essVersionQuery(synapseRoot));
+  },
+
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { credentials } = Route.useRouteContext();
+  const { data: wellKnown } = useSuspenseQuery(
+    wellKnownQuery(credentials.serverName),
+  );
+  const synapseRoot = wellKnown["m.homeserver"].base_url;
+  const variant = useEssVariant(synapseRoot);
+  const intl = useIntl();
+  const isPro = variant === "pro";
+
+  return (
+    <Navigation.Content>
+      <Navigation.Main>
+        {!isPro && (
+          <Alert
+            type="info"
+            className="max-w-[80ch]"
+            title={intl.formatMessage({
+              id: "pages.auditing.unavailable_alert.title",
+              description:
+                "Title of the alert explaining that the auditing feature is only available in ESS Pro",
+              defaultMessage: "Auditing is a feature available in ESS Pro",
+            })}
+          >
+            <FormattedMessage
+              id="pages.auditing.unavailable_alert.description"
+              description="Description of the alert explaining that the auditing feature is only available in ESS Pro"
+              defaultMessage="This feature is not available in ESS Community. Upgrade to ESS Pro to enable it."
+            />
+          </Alert>
+        )}
+
+        <Card.Stack>
+          <Marketing.AuditingCard proBadge={!isPro} />
+          {!isPro && <Marketing.AlsoAvailableInPro />}
+        </Card.Stack>
+      </Navigation.Main>
+      <AppFooter />
+    </Navigation.Content>
+  );
+}

--- a/src/ui/marketing.tsx
+++ b/src/ui/marketing.tsx
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
-import { AdminIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import {
+  AdminIcon,
+  ExportArchiveIcon,
+} from "@vector-im/compound-design-tokens/assets/web/icons";
 import { Button } from "@vector-im/compound-web";
 import { FormattedMessage } from "react-intl";
 
@@ -95,5 +98,43 @@ console to manage and moderate their rooms.</p>
       }}
       description="Description of the card explaining what moderation is"
     />
+  </Card.Root>
+);
+
+export const AuditingCard = ({ proBadge }: { proBadge?: boolean }) => (
+  <Card.Root kind="secondary">
+    <Card.Header>
+      <Card.Icon icon={ExportArchiveIcon} />
+      <Card.Title>
+        <FormattedMessage
+          id="marketing.auditing.title"
+          defaultMessage="Auditing"
+          description="Title of the card explaining what auditing is"
+        />
+      </Card.Title>
+      {proBadge && <ProBadge />}
+    </Card.Header>
+
+    <Card.Body>
+      <FormattedMessage
+        id="marketing.auditing.description"
+        defaultMessage="
+<p>Auditing gives organizations the ability to keep records of end-to-end
+encrypted conversations and room events to meet compliance or legal
+requirements.</p>
+<p>When enabled, it is visible to all end users which rooms are being recorded
+to ensure transparency of the auditing process.</p>
+<p>Auditing can be configured to suit an organization’s specific requirements.
+For instance direct messages between two individuals can be excluded so that
+only group conversations are recorded.</p>
+<p>Audit data is being stored as a stream of machine-readable events in the JSON
+format either on file storage or S3 and can be forwarded to log analyzer tooling
+for further filtering and analysis.</p>"
+        values={{
+          p: (chunks) => <p>{...chunks}</p>,
+        }}
+        description="Description of the card explaining what auditing is"
+      />
+    </Card.Body>
   </Card.Root>
 );

--- a/src/ui/navigation.tsx
+++ b/src/ui/navigation.tsx
@@ -5,6 +5,7 @@
 import {
   AdminIcon,
   DocumentIcon,
+  ExportArchiveIcon,
   HomeIcon,
   InlineCodeIcon,
   KeyIcon,
@@ -45,6 +46,13 @@ const AppNavigation = ({ features }: { features: MasFeaturesStatus }) => (
       />
     </Navigation.NavLink>
     <Navigation.Divider />
+    <Navigation.NavLink Icon={ExportArchiveIcon} to="/auditing">
+      <FormattedMessage
+        id="navigation.auditing"
+        defaultMessage="Auditing"
+        description="Label for the auditing navigation item in the main navigation sidebar"
+      />
+    </Navigation.NavLink>
     <Navigation.NavLink Icon={AdminIcon} to="/moderation">
       <FormattedMessage
         id="navigation.moderation"

--- a/translations/extracted/en.json
+++ b/translations/extracted/en.json
@@ -99,6 +99,14 @@
     "description": "When we show off a feature that is only available in ESS Pro, this is the button to lead the user to the ESS Pro upgrade page",
     "message": "Upgrade to Pro"
   },
+  "marketing.auditing.description": {
+    "description": "Description of the card explaining what auditing is",
+    "message": "<p>Auditing gives organizations the ability to keep records of end-to-end encrypted conversations and room events to meet compliance or legal requirements.</p> <p>When enabled, it is visible to all end users which rooms are being recorded to ensure transparency of the auditing process.</p> <p>Auditing can be configured to suit an organization’s specific requirements. For instance direct messages between two individuals can be excluded so that only group conversations are recorded.</p> <p>Audit data is being stored as a stream of machine-readable events in the JSON format either on file storage or S3 and can be forwarded to log analyzer tooling for further filtering and analysis.</p>"
+  },
+  "marketing.auditing.title": {
+    "description": "Title of the card explaining what auditing is",
+    "message": "Auditing"
+  },
   "marketing.moderation.description": {
     "description": "Description of the card explaining what moderation is",
     "message": "<p>Moderation enables an organisation to administer all rooms from a central point. A ‘moderator’ account will join defined rooms with room admin privileges. Server administrators can seamlessly impersonate the account from the admin console to manage and moderate their rooms.</p> <ul> <li>Manage rooms and their settings (name, topic, permissions, etc.)</li> <li>Manage room memberships</li> <li>Remove unwanted messages and uploaded media</li> <li>Recover abandoned rooms (all users have left)</li> <li>Moderator account can or cannot read encrypted message contents (configurable)</li> </ul>"
@@ -106,6 +114,10 @@
   "marketing.moderation.title": {
     "description": "Title of the card explaining what moderation is",
     "message": "Moderation"
+  },
+  "navigation.auditing": {
+    "description": "Label for the auditing navigation item in the main navigation sidebar",
+    "message": "Auditing"
   },
   "navigation.dashboard": {
     "description": "Label for the dashboard navigation item in the main navigation sidebar",
@@ -134,6 +146,18 @@
   "navigation.users": {
     "description": "Label for the users navigation item in the main navigation sidebar",
     "message": "Users"
+  },
+  "pages.auditing.title": {
+    "description": "The title of the auditing page",
+    "message": "Auditing"
+  },
+  "pages.auditing.unavailable_alert.description": {
+    "description": "Description of the alert explaining that the auditing feature is only available in ESS Pro",
+    "message": "This feature is not available in ESS Community. Upgrade to ESS Pro to enable it."
+  },
+  "pages.auditing.unavailable_alert.title": {
+    "description": "Title of the alert explaining that the auditing feature is only available in ESS Pro",
+    "message": "Auditing is a feature available in ESS Pro"
   },
   "pages.dashboard.current_ess_version": {
     "description": "On the dashboard, this shows the current ESS version",


### PR DESCRIPTION
This adds a page about "Auditing". As this is kinda a 'backend-only' feature, it only explains what it does

<img width="1840" height="1195" alt="image" src="https://github.com/user-attachments/assets/99051105-40ef-43b8-906b-9d5fe39560b6" />

<img width="1840" height="1195" alt="image" src="https://github.com/user-attachments/assets/26c3207c-da09-4af2-a36e-b213a90eed7d" />
