### PR TITLE
Rename Moderation → Supervision

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,10 +14,10 @@ import { Route as ConsoleRouteImport } from './routes/_console'
 import { Route as AuthRouteImport } from './routes/_auth'
 import { Route as ConsoleIndexRouteImport } from './routes/_console.index'
 import { Route as ConsoleUsersRouteImport } from './routes/_console.users'
+import { Route as ConsoleSupervisionRouteImport } from './routes/_console.supervision'
 import { Route as ConsoleRoomsRouteImport } from './routes/_console.rooms'
 import { Route as ConsoleRegistrationTokensRouteImport } from './routes/_console.registration-tokens'
 import { Route as ConsolePersonalTokensRouteImport } from './routes/_console.personal-tokens'
-import { Route as ConsoleModerationRouteImport } from './routes/_console.moderation'
 import { Route as ConsoleAuditingRouteImport } from './routes/_console.auditing'
 import { Route as AuthLoginIndexRouteImport } from './routes/_auth.login.index'
 import { Route as ConsoleUsersUserIdRouteImport } from './routes/_console.users.$userId'
@@ -48,6 +48,11 @@ const ConsoleUsersRoute = ConsoleUsersRouteImport.update({
   path: '/users',
   getParentRoute: () => ConsoleRoute,
 } as any)
+const ConsoleSupervisionRoute = ConsoleSupervisionRouteImport.update({
+  id: '/supervision',
+  path: '/supervision',
+  getParentRoute: () => ConsoleRoute,
+} as any)
 const ConsoleRoomsRoute = ConsoleRoomsRouteImport.update({
   id: '/rooms',
   path: '/rooms',
@@ -62,11 +67,6 @@ const ConsoleRegistrationTokensRoute =
 const ConsolePersonalTokensRoute = ConsolePersonalTokensRouteImport.update({
   id: '/personal-tokens',
   path: '/personal-tokens',
-  getParentRoute: () => ConsoleRoute,
-} as any)
-const ConsoleModerationRoute = ConsoleModerationRouteImport.update({
-  id: '/moderation',
-  path: '/moderation',
   getParentRoute: () => ConsoleRoute,
 } as any)
 const ConsoleAuditingRoute = ConsoleAuditingRouteImport.update({
@@ -106,10 +106,10 @@ export interface FileRoutesByFullPath {
   '/': typeof ConsoleIndexRoute
   '/callback': typeof CallbackRoute
   '/auditing': typeof ConsoleAuditingRoute
-  '/moderation': typeof ConsoleModerationRoute
   '/personal-tokens': typeof ConsolePersonalTokensRouteWithChildren
   '/registration-tokens': typeof ConsoleRegistrationTokensRouteWithChildren
   '/rooms': typeof ConsoleRoomsRouteWithChildren
+  '/supervision': typeof ConsoleSupervisionRoute
   '/users': typeof ConsoleUsersRouteWithChildren
   '/personal-tokens/$tokenId': typeof ConsolePersonalTokensTokenIdRoute
   '/registration-tokens/$tokenId': typeof ConsoleRegistrationTokensTokenIdRoute
@@ -121,10 +121,10 @@ export interface FileRoutesByTo {
   '/': typeof ConsoleIndexRoute
   '/callback': typeof CallbackRoute
   '/auditing': typeof ConsoleAuditingRoute
-  '/moderation': typeof ConsoleModerationRoute
   '/personal-tokens': typeof ConsolePersonalTokensRouteWithChildren
   '/registration-tokens': typeof ConsoleRegistrationTokensRouteWithChildren
   '/rooms': typeof ConsoleRoomsRouteWithChildren
+  '/supervision': typeof ConsoleSupervisionRoute
   '/users': typeof ConsoleUsersRouteWithChildren
   '/personal-tokens/$tokenId': typeof ConsolePersonalTokensTokenIdRoute
   '/registration-tokens/$tokenId': typeof ConsoleRegistrationTokensTokenIdRoute
@@ -138,10 +138,10 @@ export interface FileRoutesById {
   '/_console': typeof ConsoleRouteWithChildren
   '/callback': typeof CallbackRoute
   '/_console/auditing': typeof ConsoleAuditingRoute
-  '/_console/moderation': typeof ConsoleModerationRoute
   '/_console/personal-tokens': typeof ConsolePersonalTokensRouteWithChildren
   '/_console/registration-tokens': typeof ConsoleRegistrationTokensRouteWithChildren
   '/_console/rooms': typeof ConsoleRoomsRouteWithChildren
+  '/_console/supervision': typeof ConsoleSupervisionRoute
   '/_console/users': typeof ConsoleUsersRouteWithChildren
   '/_console/': typeof ConsoleIndexRoute
   '/_console/personal-tokens/$tokenId': typeof ConsolePersonalTokensTokenIdRoute
@@ -156,10 +156,10 @@ export interface FileRouteTypes {
     | '/'
     | '/callback'
     | '/auditing'
-    | '/moderation'
     | '/personal-tokens'
     | '/registration-tokens'
     | '/rooms'
+    | '/supervision'
     | '/users'
     | '/personal-tokens/$tokenId'
     | '/registration-tokens/$tokenId'
@@ -171,10 +171,10 @@ export interface FileRouteTypes {
     | '/'
     | '/callback'
     | '/auditing'
-    | '/moderation'
     | '/personal-tokens'
     | '/registration-tokens'
     | '/rooms'
+    | '/supervision'
     | '/users'
     | '/personal-tokens/$tokenId'
     | '/registration-tokens/$tokenId'
@@ -187,10 +187,10 @@ export interface FileRouteTypes {
     | '/_console'
     | '/callback'
     | '/_console/auditing'
-    | '/_console/moderation'
     | '/_console/personal-tokens'
     | '/_console/registration-tokens'
     | '/_console/rooms'
+    | '/_console/supervision'
     | '/_console/users'
     | '/_console/'
     | '/_console/personal-tokens/$tokenId'
@@ -243,6 +243,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ConsoleUsersRouteImport
       parentRoute: typeof ConsoleRoute
     }
+    '/_console/supervision': {
+      id: '/_console/supervision'
+      path: '/supervision'
+      fullPath: '/supervision'
+      preLoaderRoute: typeof ConsoleSupervisionRouteImport
+      parentRoute: typeof ConsoleRoute
+    }
     '/_console/rooms': {
       id: '/_console/rooms'
       path: '/rooms'
@@ -262,13 +269,6 @@ declare module '@tanstack/react-router' {
       path: '/personal-tokens'
       fullPath: '/personal-tokens'
       preLoaderRoute: typeof ConsolePersonalTokensRouteImport
-      parentRoute: typeof ConsoleRoute
-    }
-    '/_console/moderation': {
-      id: '/_console/moderation'
-      path: '/moderation'
-      fullPath: '/moderation'
-      preLoaderRoute: typeof ConsoleModerationRouteImport
       parentRoute: typeof ConsoleRoute
     }
     '/_console/auditing': {
@@ -380,20 +380,20 @@ const ConsoleUsersRouteWithChildren = ConsoleUsersRoute._addFileChildren(
 
 interface ConsoleRouteChildren {
   ConsoleAuditingRoute: typeof ConsoleAuditingRoute
-  ConsoleModerationRoute: typeof ConsoleModerationRoute
   ConsolePersonalTokensRoute: typeof ConsolePersonalTokensRouteWithChildren
   ConsoleRegistrationTokensRoute: typeof ConsoleRegistrationTokensRouteWithChildren
   ConsoleRoomsRoute: typeof ConsoleRoomsRouteWithChildren
+  ConsoleSupervisionRoute: typeof ConsoleSupervisionRoute
   ConsoleUsersRoute: typeof ConsoleUsersRouteWithChildren
   ConsoleIndexRoute: typeof ConsoleIndexRoute
 }
 
 const ConsoleRouteChildren: ConsoleRouteChildren = {
   ConsoleAuditingRoute: ConsoleAuditingRoute,
-  ConsoleModerationRoute: ConsoleModerationRoute,
   ConsolePersonalTokensRoute: ConsolePersonalTokensRouteWithChildren,
   ConsoleRegistrationTokensRoute: ConsoleRegistrationTokensRouteWithChildren,
   ConsoleRoomsRoute: ConsoleRoomsRouteWithChildren,
+  ConsoleSupervisionRoute: ConsoleSupervisionRoute,
   ConsoleUsersRoute: ConsoleUsersRouteWithChildren,
   ConsoleIndexRoute: ConsoleIndexRoute,
 }

--- a/src/routes/_console.supervision.tsx
+++ b/src/routes/_console.supervision.tsx
@@ -38,12 +38,12 @@ import * as Marketing from "@/ui/marketing";
 import { assertNever } from "@/utils/never";
 
 const titleMessage = defineMessage({
-  id: "pages.moderation.title",
-  defaultMessage: "Moderation",
-  description: "The title of the moderation page",
+  id: "pages.supervision.title",
+  defaultMessage: "Supervision",
+  description: "The title of the supervision page",
 });
 
-export const Route = createFileRoute("/_console/moderation")({
+export const Route = createFileRoute("/_console/supervision")({
   staticData: {
     breadcrumb: {
       message: titleMessage,
@@ -79,7 +79,7 @@ const messageSchema = v.picklist(["loaded", "authenticated", "missing-config"]);
 
 type Result = "ok" | "cant open" | "closed";
 
-async function openModeration({
+async function openSupervision({
   instance,
   hostname,
   userId,
@@ -87,7 +87,7 @@ async function openModeration({
   deviceId,
 }: Config): Promise<Result> {
   const controller = new AbortController();
-  const loginWindow = globalThis.window.open(instance, "moderation-ui");
+  const loginWindow = globalThis.window.open(instance, "supervision-ui");
   if (loginWindow === null || loginWindow.closed) {
     return "cant open";
   }
@@ -214,7 +214,7 @@ function LaunchAdminbot({
 }: LaunchAdminbotProps) {
   const intl = useIntl();
   const { mutate, isPending, error, data } = useMutation({
-    mutationFn: openModeration,
+    mutationFn: openSupervision,
   });
 
   const onClick = useCallback(
@@ -238,17 +238,17 @@ function LaunchAdminbot({
         <Alert
           type="critical"
           title={intl.formatMessage({
-            id: "pages.moderation.errors.cant_open.title",
+            id: "pages.supervision.errors.cant_open.title",
             defaultMessage:
-              "Failed to open the moderation interface in a new window",
+              "Failed to open the supervision interface in a new window",
             description:
-              "The title of the error message when the moderation interface can't be opened",
+              "The title of the error message when the supervision interface can't be opened",
           })}
         >
           <FormattedMessage
-            id="pages.moderation.errors.cant_open.description"
+            id="pages.supervision.errors.cant_open.description"
             defaultMessage="Your browser is blocking the opening of pop-up windows. Please make sure you allow pop-ups from this site."
-            description="The description of the error message when the moderation interface can't be opened in a new window"
+            description="The description of the error message when the supervision interface can't be opened in a new window"
           />
         </Alert>
       )}
@@ -257,16 +257,16 @@ function LaunchAdminbot({
         <Alert
           type="critical"
           title={intl.formatMessage({
-            id: "pages.moderation.errors.closed.title",
-            defaultMessage: "The moderation interface was closed too quickly",
+            id: "pages.supervision.errors.closed.title",
+            defaultMessage: "The supervision interface was closed too quickly",
             description:
-              "The title of the error message when the moderation interface was closed",
+              "The title of the error message when the supervision interface was closed",
           })}
         >
           <FormattedMessage
-            id="pages.moderation.errors.closed.description"
-            defaultMessage="Failed to sign in the moderation interface, as it closed before it could finish signing in"
-            description="The description of the error message when the moderation interface was closed"
+            id="pages.supervision.errors.closed.description"
+            defaultMessage="Failed to sign in the supervision interface, as it closed before it could finish signing in"
+            description="The description of the error message when the supervision interface was closed"
           />
         </Alert>
       )}
@@ -275,11 +275,11 @@ function LaunchAdminbot({
         <Alert
           type="critical"
           title={intl.formatMessage({
-            id: "pages.moderation.errors.generic.title",
+            id: "pages.supervision.errors.generic.title",
             defaultMessage:
-              "An unexpected error occurred whilst opening the moderation interface",
+              "An unexpected error occurred whilst opening the supervision interface",
             description:
-              "The title of the error message when the moderation interface can't be opened",
+              "The title of the error message when the supervision interface can't be opened",
           })}
         >
           {String(error)}
@@ -319,9 +319,9 @@ function AdminbotContent({ config, synapseRoot }: AdminbotContentProps) {
       <div className="flex flex-col gap-6 max-w-[60ch]">
         <Text size="md" className="text-pretty">
           <FormattedMessage
-            id="pages.moderation.description"
+            id="pages.supervision.description"
             defaultMessage="Sign in as <b>{mxid}</b> to perform administrative actions in any room."
-            description="The description of the moderation page"
+            description="The description of the supervision page"
             values={{
               mxid: config.mxid,
               b: (chunks) => <b>{...chunks}</b>,
@@ -341,17 +341,17 @@ function AdminbotContent({ config, synapseRoot }: AdminbotContentProps) {
           <Alert
             type="critical"
             title={intl.formatMessage({
-              id: "pages.moderation.missing_ui_address.title",
+              id: "pages.supervision.missing_ui_address.title",
               description:
                 "When adminbot is enabled, but the Element Web is not deployed with ESS, we show an alert, as the UI feature relies on it. This is the title of said alert.",
               defaultMessage:
-                "The moderation interface requires Element Web to be enabled",
+                "The supervision interface requires Element Web to be enabled",
             })}
           >
             <FormattedMessage
-              id="pages.moderation.missing_ui_address.description"
+              id="pages.supervision.missing_ui_address.description"
               description="When adminbot is enabled, but the Element Web is not deployed with ESS, we show an alert, as the UI feature relies on it. This is the description of said alert."
-              defaultMessage="Moderation is enabled in your deployment, but not Element Web, which is required for the moderation interface to work."
+              defaultMessage="Supervision is enabled in your deployment, but not Element Web, which is required for the supervision interface to work."
             />
           </Alert>
         )}
@@ -377,9 +377,9 @@ function SecurePassphrase({ value }: SecurePassphraseProps) {
         await navigator.clipboard.writeText(value);
         toast.success(
           intl.formatMessage({
-            id: "pages.moderation.recovery_key.copied",
+            id: "pages.supervision.recovery_key.copied",
             description:
-              "On the moderation page, message displayed when the recovery key is copied to the clipboard",
+              "On the supervision page, message displayed when the recovery key is copied to the clipboard",
             defaultMessage: "Recovery key copied",
           }),
         );
@@ -387,9 +387,9 @@ function SecurePassphrase({ value }: SecurePassphraseProps) {
         console.error("Could not copy recovery key to the clipboard", error);
         toast.error(
           intl.formatMessage({
-            id: "pages.moderation.recovery_key.copy_failed",
+            id: "pages.supervision.recovery_key.copy_failed",
             description:
-              "On the moderation page, message displayed when the recovery key could not be copied to the clipboard",
+              "On the supervision page, message displayed when the recovery key could not be copied to the clipboard",
             defaultMessage: "Could not copy recovery key",
           }),
         );
@@ -406,8 +406,8 @@ function SecurePassphrase({ value }: SecurePassphraseProps) {
       <Form.Field name="passphrase">
         <Form.Label>
           <FormattedMessage
-            id="pages.moderation.recovery_key.label"
-            description="On the moderation page, label for the recovery key readonly input field"
+            id="pages.supervision.recovery_key.label"
+            description="On the supervision page, label for the recovery key readonly input field"
             defaultMessage="Recovery key"
           />
         </Form.Label>
@@ -430,8 +430,8 @@ function SecurePassphrase({ value }: SecurePassphraseProps) {
         </div>
         <Form.HelpMessage className="text-pretty">
           <FormattedMessage
-            id="pages.moderation.recovery_key.help"
-            description="On the moderation page, help text for the recovery key readonly input field"
+            id="pages.supervision.recovery_key.help"
+            description="On the supervision page, help text for the recovery key readonly input field"
             defaultMessage="This is the recovery key used to enable reading encrypted messages."
           />
         </Form.HelpMessage>
@@ -453,14 +453,14 @@ function AdminbotDisabled({ isPro }: AdminbotDisabledProps) {
           type="info"
           className="max-w-[80ch]"
           title={intl.formatMessage({
-            id: "pages.moderation.disabled_alert.title",
+            id: "pages.supervision.disabled_alert.title",
             description:
               "When the feature is disabled on an ESS Pro deployment, this is the title of the alert message telling admins to configure it",
-            defaultMessage: "Moderation is currently disabled",
+            defaultMessage: "Supervision is currently disabled",
           })}
         >
           <FormattedMessage
-            id="pages.moderation.disabled_alert.description"
+            id="pages.supervision.disabled_alert.description"
             description="When the feature is disabled on an ESS Pro deployment, this is the description of the alert message telling admins to configure it"
             defaultMessage="This feature is part of your subscription. You can ask an administrator to enable it."
           />
@@ -470,22 +470,22 @@ function AdminbotDisabled({ isPro }: AdminbotDisabledProps) {
           type="info"
           className="max-w-[80ch]"
           title={intl.formatMessage({
-            id: "pages.moderation.unavailable_alert.title",
+            id: "pages.supervision.unavailable_alert.title",
             description:
-              "Title of the alert explaining that the moderation feature is only available in ESS Pro",
-            defaultMessage: "Moderation is a feature available in ESS Pro",
+              "Title of the alert explaining that the supervision feature is only available in ESS Pro",
+            defaultMessage: "Supervision is a feature available in ESS Pro",
           })}
         >
           <FormattedMessage
-            id="pages.moderation.unavailable_alert.description"
-            description="Description of the alert explaining that the moderation feature is only available in ESS Pro"
+            id="pages.supervision.unavailable_alert.description"
+            description="Description of the alert explaining that the supervision feature is only available in ESS Pro"
             defaultMessage="This feature is not available in ESS Community. Upgrade to ESS Pro to enable it."
           />
         </Alert>
       )}
 
       <Card.Stack>
-        <Marketing.ModerationCard proBadge={!isPro} />
+        <Marketing.SupervisionCard proBadge={!isPro} />
         {!isPro && <Marketing.AlsoAvailableInPro />}
       </Card.Stack>
     </>

--- a/src/ui/marketing.tsx
+++ b/src/ui/marketing.tsx
@@ -70,40 +70,40 @@ compliance, scalability, high availability and multi-tenancy.</p>"
   </Card.Root>
 );
 
-export const ModerationCard = ({ proBadge }: { proBadge?: boolean }) => (
+export const SupervisionCard = ({ proBadge }: { proBadge?: boolean }) => (
   <Card.Root kind="secondary">
     <Card.Header>
       <Card.Icon icon={AdminIcon} />
       <Card.Title>
         <FormattedMessage
-          id="marketing.moderation.title"
-          defaultMessage="Moderation"
-          description="Title of the card explaining what moderation is"
+          id="marketing.supervision.title"
+          defaultMessage="Supervision"
+          description="Title of the card explaining what supervision is"
         />
       </Card.Title>
       {proBadge && <ProBadge />}
     </Card.Header>
 
     <FormattedMessage
-      id="marketing.moderation.description"
+      id="marketing.supervision.description"
       defaultMessage="
-<p>Moderation enables an organisation to administer all rooms from a central
-point. A ‘moderator’ account will join defined rooms with room admin privileges.
+<p>Supervision enables an organisation to administer all rooms from a central
+point. A 'supervisor' account will join defined rooms with room admin privileges.
 Server administrators can seamlessly impersonate the account from the admin
-console to manage and moderate their rooms.</p>
+console to manage and supervise their rooms.</p>
 <ul>
 <li>Manage rooms and their settings (name, topic, permissions, etc.)</li>
 <li>Manage room memberships</li>
 <li>Remove unwanted messages and uploaded media</li>
 <li>Recover abandoned rooms (all users have left)</li>
-<li>Moderator account can or cannot read encrypted message contents (configurable)</li>
+<li>Supervisor account can or cannot read encrypted message contents (configurable)</li>
 </ul>"
       values={{
         p: (chunks) => <Card.Body>{...chunks}</Card.Body>,
         ul: (chunks) => <Card.Checklist>{...chunks}</Card.Checklist>,
         li: (chunks) => <Card.ChecklistItem>{...chunks}</Card.ChecklistItem>,
       }}
-      description="Description of the card explaining what moderation is"
+      description="Description of the card explaining what supervision is"
     />
   </Card.Root>
 );

--- a/src/ui/navigation.tsx
+++ b/src/ui/navigation.tsx
@@ -54,11 +54,11 @@ const AppNavigation = ({ features }: { features: MasFeaturesStatus }) => (
         description="Label for the auditing navigation item in the main navigation sidebar"
       />
     </Navigation.NavLink>
-    <Navigation.NavLink Icon={AdminIcon} to="/moderation">
+    <Navigation.NavLink Icon={AdminIcon} to="/supervision">
       <FormattedMessage
-        id="navigation.moderation"
-        defaultMessage="Moderation"
-        description="Label for the moderation navigation item in the main navigation sidebar"
+        id="navigation.supervision"
+        defaultMessage="Supervision"
+        description="Label for the supervision navigation item in the main navigation sidebar"
       />
     </Navigation.NavLink>
     <Navigation.Divider />

--- a/translations/extracted/en.json
+++ b/translations/extracted/en.json
@@ -111,13 +111,13 @@
     "description": "Title of the card explaining what auditing is",
     "message": "Auditing"
   },
-  "marketing.moderation.description": {
-    "description": "Description of the card explaining what moderation is",
-    "message": "<p>Moderation enables an organisation to administer all rooms from a central point. A ‘moderator’ account will join defined rooms with room admin privileges. Server administrators can seamlessly impersonate the account from the admin console to manage and moderate their rooms.</p> <ul> <li>Manage rooms and their settings (name, topic, permissions, etc.)</li> <li>Manage room memberships</li> <li>Remove unwanted messages and uploaded media</li> <li>Recover abandoned rooms (all users have left)</li> <li>Moderator account can or cannot read encrypted message contents (configurable)</li> </ul>"
+  "marketing.supervision.description": {
+    "description": "Description of the card explaining what supervision is",
+    "message": "<p>Supervision enables an organisation to administer all rooms from a central point. A 'supervisor' account will join defined rooms with room admin privileges. Server administrators can seamlessly impersonate the account from the admin console to manage and supervise their rooms.</p> <ul> <li>Manage rooms and their settings (name, topic, permissions, etc.)</li> <li>Manage room memberships</li> <li>Remove unwanted messages and uploaded media</li> <li>Recover abandoned rooms (all users have left)</li> <li>Supervisor account can or cannot read encrypted message contents (configurable)</li> </ul>"
   },
-  "marketing.moderation.title": {
-    "description": "Title of the card explaining what moderation is",
-    "message": "Moderation"
+  "marketing.supervision.title": {
+    "description": "Title of the card explaining what supervision is",
+    "message": "Supervision"
   },
   "navigation.auditing": {
     "description": "Label for the auditing navigation item in the main navigation sidebar",
@@ -131,10 +131,6 @@
     "description": "Label for the documentation navigation link (to https://docs.element.io/) in the main navigation sidebar",
     "message": "Documentation"
   },
-  "navigation.moderation": {
-    "description": "Label for the moderation navigation item in the main navigation sidebar",
-    "message": "Moderation"
-  },
   "navigation.personal_tokens": {
     "description": "Label for the personal tokens navigation item in the main navigation sidebar",
     "message": "Personal tokens"
@@ -146,6 +142,10 @@
   "navigation.rooms": {
     "description": "Label for the rooms navigation item in the main navigation sidebar",
     "message": "Rooms"
+  },
+  "navigation.supervision": {
+    "description": "Label for the supervision navigation item in the main navigation sidebar",
+    "message": "Supervision"
   },
   "navigation.users": {
     "description": "Label for the users navigation item in the main navigation sidebar",
@@ -242,74 +242,6 @@
   "pages.login.title": {
     "description": "Title for the login page",
     "message": "Login"
-  },
-  "pages.moderation.description": {
-    "description": "The description of the moderation page",
-    "message": "Sign in as <b>{mxid}</b> to perform administrative actions in any room."
-  },
-  "pages.moderation.disabled_alert.description": {
-    "description": "When the feature is disabled on an ESS Pro deployment, this is the description of the alert message telling admins to configure it",
-    "message": "This feature is part of your subscription. You can ask an administrator to enable it."
-  },
-  "pages.moderation.disabled_alert.title": {
-    "description": "When the feature is disabled on an ESS Pro deployment, this is the title of the alert message telling admins to configure it",
-    "message": "Moderation is currently disabled"
-  },
-  "pages.moderation.errors.cant_open.description": {
-    "description": "The description of the error message when the moderation interface can't be opened in a new window",
-    "message": "Your browser is blocking the opening of pop-up windows. Please make sure you allow pop-ups from this site."
-  },
-  "pages.moderation.errors.cant_open.title": {
-    "description": "The title of the error message when the moderation interface can't be opened",
-    "message": "Failed to open the moderation interface in a new window"
-  },
-  "pages.moderation.errors.closed.description": {
-    "description": "The description of the error message when the moderation interface was closed",
-    "message": "Failed to sign in the moderation interface, as it closed before it could finish signing in"
-  },
-  "pages.moderation.errors.closed.title": {
-    "description": "The title of the error message when the moderation interface was closed",
-    "message": "The moderation interface was closed too quickly"
-  },
-  "pages.moderation.errors.generic.title": {
-    "description": "The title of the error message when the moderation interface can't be opened",
-    "message": "An unexpected error occurred whilst opening the moderation interface"
-  },
-  "pages.moderation.missing_ui_address.description": {
-    "description": "When adminbot is enabled, but the Element Web is not deployed with ESS, we show an alert, as the UI feature relies on it. This is the description of said alert.",
-    "message": "Moderation is enabled in your deployment, but not Element Web, which is required for the moderation interface to work."
-  },
-  "pages.moderation.missing_ui_address.title": {
-    "description": "When adminbot is enabled, but the Element Web is not deployed with ESS, we show an alert, as the UI feature relies on it. This is the title of said alert.",
-    "message": "The moderation interface requires Element Web to be enabled"
-  },
-  "pages.moderation.recovery_key.copied": {
-    "description": "On the moderation page, message displayed when the recovery key is copied to the clipboard",
-    "message": "Recovery key copied"
-  },
-  "pages.moderation.recovery_key.copy_failed": {
-    "description": "On the moderation page, message displayed when the recovery key could not be copied to the clipboard",
-    "message": "Could not copy recovery key"
-  },
-  "pages.moderation.recovery_key.help": {
-    "description": "On the moderation page, help text for the recovery key readonly input field",
-    "message": "This is the recovery key used to enable reading encrypted messages."
-  },
-  "pages.moderation.recovery_key.label": {
-    "description": "On the moderation page, label for the recovery key readonly input field",
-    "message": "Recovery key"
-  },
-  "pages.moderation.title": {
-    "description": "The title of the moderation page",
-    "message": "Moderation"
-  },
-  "pages.moderation.unavailable_alert.description": {
-    "description": "Description of the alert explaining that the moderation feature is only available in ESS Pro",
-    "message": "This feature is not available in ESS Community. Upgrade to ESS Pro to enable it."
-  },
-  "pages.moderation.unavailable_alert.title": {
-    "description": "Title of the alert explaining that the moderation feature is only available in ESS Pro",
-    "message": "Moderation is a feature available in ESS Pro"
   },
   "pages.personal_tokens.acting_user_column": {
     "description": "Column header for acting user column",
@@ -854,6 +786,74 @@
   "pages.rooms.title": {
     "description": "The title of the rooms list page",
     "message": "Rooms"
+  },
+  "pages.supervision.description": {
+    "description": "The description of the supervision page",
+    "message": "Sign in as <b>{mxid}</b> to perform administrative actions in any room."
+  },
+  "pages.supervision.disabled_alert.description": {
+    "description": "When the feature is disabled on an ESS Pro deployment, this is the description of the alert message telling admins to configure it",
+    "message": "This feature is part of your subscription. You can ask an administrator to enable it."
+  },
+  "pages.supervision.disabled_alert.title": {
+    "description": "When the feature is disabled on an ESS Pro deployment, this is the title of the alert message telling admins to configure it",
+    "message": "Supervision is currently disabled"
+  },
+  "pages.supervision.errors.cant_open.description": {
+    "description": "The description of the error message when the supervision interface can't be opened in a new window",
+    "message": "Your browser is blocking the opening of pop-up windows. Please make sure you allow pop-ups from this site."
+  },
+  "pages.supervision.errors.cant_open.title": {
+    "description": "The title of the error message when the supervision interface can't be opened",
+    "message": "Failed to open the supervision interface in a new window"
+  },
+  "pages.supervision.errors.closed.description": {
+    "description": "The description of the error message when the supervision interface was closed",
+    "message": "Failed to sign in the supervision interface, as it closed before it could finish signing in"
+  },
+  "pages.supervision.errors.closed.title": {
+    "description": "The title of the error message when the supervision interface was closed",
+    "message": "The supervision interface was closed too quickly"
+  },
+  "pages.supervision.errors.generic.title": {
+    "description": "The title of the error message when the supervision interface can't be opened",
+    "message": "An unexpected error occurred whilst opening the supervision interface"
+  },
+  "pages.supervision.missing_ui_address.description": {
+    "description": "When adminbot is enabled, but the Element Web is not deployed with ESS, we show an alert, as the UI feature relies on it. This is the description of said alert.",
+    "message": "Supervision is enabled in your deployment, but not Element Web, which is required for the supervision interface to work."
+  },
+  "pages.supervision.missing_ui_address.title": {
+    "description": "When adminbot is enabled, but the Element Web is not deployed with ESS, we show an alert, as the UI feature relies on it. This is the title of said alert.",
+    "message": "The supervision interface requires Element Web to be enabled"
+  },
+  "pages.supervision.recovery_key.copied": {
+    "description": "On the supervision page, message displayed when the recovery key is copied to the clipboard",
+    "message": "Recovery key copied"
+  },
+  "pages.supervision.recovery_key.copy_failed": {
+    "description": "On the supervision page, message displayed when the recovery key could not be copied to the clipboard",
+    "message": "Could not copy recovery key"
+  },
+  "pages.supervision.recovery_key.help": {
+    "description": "On the supervision page, help text for the recovery key readonly input field",
+    "message": "This is the recovery key used to enable reading encrypted messages."
+  },
+  "pages.supervision.recovery_key.label": {
+    "description": "On the supervision page, label for the recovery key readonly input field",
+    "message": "Recovery key"
+  },
+  "pages.supervision.title": {
+    "description": "The title of the supervision page",
+    "message": "Supervision"
+  },
+  "pages.supervision.unavailable_alert.description": {
+    "description": "Description of the alert explaining that the supervision feature is only available in ESS Pro",
+    "message": "This feature is not available in ESS Community. Upgrade to ESS Pro to enable it."
+  },
+  "pages.supervision.unavailable_alert.title": {
+    "description": "Title of the alert explaining that the supervision feature is only available in ESS Pro",
+    "message": "Supervision is a feature available in ESS Pro"
   },
   "pages.users.add_email.button": {
     "description": "The label of the button for adding an email address to a user",


### PR DESCRIPTION
Rename the moderation route, navigation, and marketing components to use "Supervision" branding instead of "Moderation".
Update all i18n message IDs and default messages accordingly.

Ref: https://github.com/element-hq/serverproduct-internal/issues/1161
