### PR TITLE
Run knip in CI and configure production mode

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Run the linters
         run: pnpm lint
 
+      - name: Check for unused files, exports and dependencies
+        run: pnpm knip
+
   playwright:
     name: E2E tests
     runs-on: ubuntu-24.04

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "license": "SEE LICENSE IN README.md",
   "scripts": {
     "dev": "vite --port 3000",
-    "start": "vite --port 3000",
     "build": "vite build",
     "serve": "vite preview",
+    "knip": "knip && knip --production",
     "lint": "oxlint && stylelint 'src/**/*.css' && oxfmt --check",
     "fix": "oxlint --fix && stylelint --fix 'src/**/*.css' && oxfmt",
     "i18n:extract": "formatjs extract --throws --format crowdin 'src/**/*.{ts,tsx}' --out-file translations/extracted/en.json && oxfmt translations/extracted/en.json",
@@ -108,8 +108,11 @@
   },
   "knip": {
     "entry": [
-      "src/base.css",
-      "src/prerender.tsx"
+      "src/base.css!",
+      "src/prerender.tsx!"
+    ],
+    "project": [
+      "src/**/*!"
     ],
     "ignore": [
       "src/api/mas/api/**/*",


### PR DESCRIPTION
This should ensure we've got the right split between development and production dependencies