### PR TITLE
Fix translation escaping

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -69,7 +69,7 @@ export class MatrixStandardError extends LocalizedError {
   localizedMessage = defineMessage({
     id: "errors.matrix_standard",
     defaultMessage:
-      "Request to the homeserver failed with error code '{errorCode}'. Additionally, the server gave the following error message: {errorMessage}",
+      "Request to the homeserver failed with error code ''{errorCode}''. Additionally, the server gave the following error message: {errorMessage}",
     description:
       "Generic error message when Synapse returned a rich error, with an error code (M_FORBIDDEN, etc.) and a human-readable error message, usually in english.",
   });

--- a/translations/extracted/en.json
+++ b/translations/extracted/en.json
@@ -64,7 +64,7 @@
     "description": "Generic error message when we fail to make a request to the specified URL. Typical values for 'status' are '404' or '500', typical values for 'statusText' are 'Not Found' or 'Internal Server Error'"
   },
   "errors.matrix_standard": {
-    "message": "Request to the homeserver failed with error code '{errorCode}'. Additionally, the server gave the following error message: {errorMessage}",
+    "message": "Request to the homeserver failed with error code ''{errorCode}''. Additionally, the server gave the following error message: {errorMessage}",
     "description": "Generic error message when Synapse returned a rich error, with an error code (M_FORBIDDEN, etc.) and a human-readable error message, usually in english."
   },
   "errors.not_logged_in": {


### PR DESCRIPTION
ICU messages use ' as escaping character, which made the '{errorCode}' placeholder not work in the error.matrix_standard message