### PR TITLE
Install Playwright browsers in CI instead of using the container image

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -64,9 +64,6 @@ jobs:
     permissions:
       contents: read
 
-    # Keep in sync with the @playwright/test version in package.json
-    container: mcr.microsoft.com/playwright:v1.62.1-noble
-
     steps:
       - name: Checkout the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -74,6 +71,9 @@ jobs:
           persist-credentials: false
 
       - uses: ./.github/actions/setup-node
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium webkit
 
       - name: Build frontend
         run: pnpm build


### PR DESCRIPTION
Replaces the `mcr.microsoft.com/playwright:v1.62.1-noble` container on the E2E job with `pnpm exec playwright install --with-deps chromium webkit`.

This means we won't have to keep those in sync anymore, even if it takes a bit more time to install.