### PR TITLE
Fix the personal token expiry display and the expiry input

### DIFF
--- a/src/routes/_console.personal-tokens.$tokenId.tsx
+++ b/src/routes/_console.personal-tokens.$tokenId.tsx
@@ -24,7 +24,7 @@ import {
   Text,
   Tooltip,
 } from "@vector-im/compound-web";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "react-hot-toast";
 import { defineMessage, FormattedMessage, useIntl } from "react-intl";
 
@@ -43,7 +43,12 @@ import { ButtonLink } from "@/components/link";
 import * as Navigation from "@/components/navigation";
 import * as messages from "@/messages";
 import { UserCard } from "@/ui/entity-cards";
-import { personalTokenExpiryText } from "@/ui/token-expiry";
+import {
+  DEFAULT_EXPIRY_DAYS,
+  TokenExpiryField,
+  daysUntilExpiry,
+  personalTokenExpiryText,
+} from "@/ui/token-expiry";
 import { PersonalTokenStatusBadge } from "@/ui/token-status-badge";
 import { computeHumanReadableDateTimeStringFromUtc } from "@/utils/datetime";
 
@@ -545,6 +550,22 @@ function RegenerateTokenModal({
   const [isOpen, setIsOpen] = useState(false);
   const intl = useIntl();
 
+  // Pinned to the token rather than recomputed every render, so the day count
+  // the field starts at cannot change under a dialog that is already open.
+  const remainingDays = useMemo(
+    () => daysUntilExpiry(token.attributes.expires_at),
+    [token.attributes.expires_at],
+  );
+  const wasExpiring = Boolean(token.attributes.expires_at);
+  const [expiresChecked, setExpiresChecked] = useState(wasExpiring);
+
+  const onExpiresChecked = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setExpiresChecked(event.currentTarget.checked);
+    },
+    [],
+  );
+
   const regenerateTokenMutation = useMutation({
     mutationFn: async (expiresIn: null | number) =>
       regeneratePersonalSession(queryClient, serverName, token.id, {
@@ -596,31 +617,37 @@ function RegenerateTokenModal({
       }
 
       const formData = new FormData(event.currentTarget);
-      const expiresInDays = formData.get("expires_in_days") as string;
+      // Absent unless the expiry checkbox was ticked; see `TokenExpiryField`.
+      const expiresInDays = formData.get("expires_in_days") as string | null;
 
-      const expiresIn =
-        expiresInDays && expiresInDays !== ""
-          ? Number.parseInt(expiresInDays, 10) * 24 * 60 * 60
-          : null;
+      const expiresIn = expiresInDays
+        ? Number.parseInt(expiresInDays, 10) * 24 * 60 * 60
+        : null;
 
       mutate(expiresIn);
     },
     [mutate, isPending],
   );
 
-  const handleClose = useCallback(() => {
-    if (isPending) {
-      return;
-    }
+  // Every open and close goes through here, so a dismissed dialog cannot leave
+  // the expiry checkbox on a choice the admin backed out of.
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (isPending) {
+        return;
+      }
 
-    setIsOpen(false);
-    reset();
-  }, [isPending, reset]);
+      setIsOpen(open);
+      reset();
+      setExpiresChecked(wasExpiring);
+    },
+    [isPending, reset, wasExpiring],
+  );
 
   return (
     <Dialog.Root
       open={isOpen}
-      onOpenChange={setIsOpen}
+      onOpenChange={onOpenChange}
       // The token is shown exactly once, so only the explicit "Done" button
       // may close the dialog while it is on screen.
       dismissible={!mutationData?.data.attributes.access_token}
@@ -683,31 +710,11 @@ function RegenerateTokenModal({
                 />
               </Text>
 
-              <Form.Field name="expires_in_days" serverInvalid={false}>
-                <Form.Label>
-                  <FormattedMessage
-                    id="pages.personal_tokens.expires_in_label"
-                    defaultMessage="Expires in (days)"
-                    description="Label for the expiry field"
-                  />
-                </Form.Label>
-                <Form.TextControl
-                  type="number"
-                  min="1"
-                  placeholder={intl.formatMessage({
-                    id: "pages.personal_tokens.expires_in_placeholder",
-                    defaultMessage: "30",
-                    description: "Placeholder for the expiry field",
-                  })}
-                />
-                <Form.HelpMessage>
-                  <FormattedMessage
-                    id="pages.personal_tokens.regenerate_expires_help"
-                    defaultMessage="Leave empty to keep the same expiry as before, or set a new expiry time"
-                    description="Help text for the expiry field when regenerating"
-                  />
-                </Form.HelpMessage>
-              </Form.Field>
+              <TokenExpiryField
+                checked={expiresChecked}
+                onChange={onExpiresChecked}
+                defaultDays={remainingDays ?? DEFAULT_EXPIRY_DAYS}
+              />
             </div>
 
             <Form.Submit
@@ -733,7 +740,6 @@ function RegenerateTokenModal({
           kind={
             mutationData?.data.attributes.access_token ? "primary" : "tertiary"
           }
-          onClick={handleClose}
           disabled={isPending}
         >
           {mutationData?.data.attributes.access_token ? (

--- a/src/routes/_console.personal-tokens.$tokenId.tsx
+++ b/src/routes/_console.personal-tokens.$tokenId.tsx
@@ -43,6 +43,7 @@ import { ButtonLink } from "@/components/link";
 import * as Navigation from "@/components/navigation";
 import * as messages from "@/messages";
 import { UserCard } from "@/ui/entity-cards";
+import { personalTokenExpiryText } from "@/ui/token-expiry";
 import { PersonalTokenStatusBadge } from "@/ui/token-status-badge";
 import { computeHumanReadableDateTimeStringFromUtc } from "@/utils/datetime";
 
@@ -423,16 +424,7 @@ function TokenDetailComponent() {
               />
             </Data.Title>
             <Data.Value>
-              {token.attributes.expires_at
-                ? computeHumanReadableDateTimeStringFromUtc(
-                    token.attributes.expires_at,
-                  )
-                : intl.formatMessage({
-                    id: "pages.personal_tokens.never_expires",
-                    defaultMessage: "Never expires",
-                    description:
-                      "Text shown when a token has no expiration date",
-                  })}
+              {personalTokenExpiryText(intl, token.attributes)}
             </Data.Value>
           </Data.Item>
 

--- a/src/routes/_console.personal-tokens.tsx
+++ b/src/routes/_console.personal-tokens.tsx
@@ -436,110 +436,122 @@ const PersonalTokenAddButton = ({
                 </Form.HelpMessage>
               </Form.Field>
 
-              <Form.InlineField
-                name="scope_mas_admin"
-                control={<Form.CheckboxControl />}
-              >
-                <Form.Label>{MAS_ADMIN_SCOPE}</Form.Label>
-                <Form.HelpMessage>
-                  <FormattedMessage
-                    id="pages.personal_tokens.scope_mas_admin_help"
-                    defaultMessage="Access to the MAS admin API"
-                    description="Help text for MAS admin scope"
-                  />
-                </Form.HelpMessage>
-              </Form.InlineField>
-
-              <Form.InlineField
-                name="scope_matrix_client"
-                control={
-                  <Form.CheckboxControl
-                    readOnly={deviceChecked || synapseAdminChecked}
-                    checked={matrixClientChecked}
-                    onChange={onMatrixClientChecked}
-                  />
-                }
-              >
-                <Form.Label>{MATRIX_API_SCOPE}</Form.Label>
-                <Form.HelpMessage>
-                  <FormattedMessage
-                    id="pages.personal_tokens.scope_matrix_client_help"
-                    defaultMessage="Access to the Matrix Client-Server API"
-                    description="Help text for Matrix Client API scope"
-                  />
-                </Form.HelpMessage>
-              </Form.InlineField>
-
-              <Form.InlineField
-                name="scope_synapse_admin"
-                control={
-                  <Form.CheckboxControl
-                    checked={synapseAdminChecked}
-                    onChange={onSynapseAdminChecked}
-                  />
-                }
-              >
-                <Form.Label>{SYNAPSE_ADMIN_SCOPE}</Form.Label>
-                <Form.HelpMessage>
-                  <FormattedMessage
-                    id="pages.personal_tokens.scope_synapse_admin_help"
-                    defaultMessage="Access to the Synapse admin API"
-                    description="Help text for Synapse admin scope"
-                  />
-                </Form.HelpMessage>
-              </Form.InlineField>
-
-              <Form.InlineField
-                name="scope_device"
-                control={
-                  <Form.CheckboxControl
-                    checked={deviceChecked}
-                    onChange={onDeviceChecked}
-                    disabled={!matrixClientChecked}
-                  />
-                }
-              >
-                <Form.Label>{DEVICE_SCOPE}</Form.Label>
-                <Form.HelpMessage>
-                  <FormattedMessage
-                    id="pages.personal_tokens.scope_device_help"
-                    defaultMessage="Provision a Matrix device"
-                    description="Help text for device scope"
-                  />
-                </Form.HelpMessage>
-              </Form.InlineField>
-
-              {deviceChecked && (
-                <Form.Field name="device_id" serverInvalid={false}>
-                  <Form.Label>
-                    <FormattedMessage
-                      id="pages.personal_tokens.device_id_label"
-                      defaultMessage="Device ID"
-                      description="Label for device ID field"
-                    />
-                  </Form.Label>
-                  <Form.TextControl
-                    placeholder={intl.formatMessage({
-                      id: "pages.personal_tokens.device_id_placeholder",
-                      defaultMessage: "ABCDEFGHIJ",
-                      description: "Placeholder for device ID field",
-                    })}
-                  />
-                  <Form.HelpMessage>
-                    <FormattedMessage
-                      id="pages.personal_tokens.device_id_help"
-                      defaultMessage="Leave empty to generate a random 10-character device ID"
-                      description="Help text for device ID field"
-                    />
-                  </Form.HelpMessage>
-                </Form.Field>
-              )}
-
               <TokenExpiryField
                 checked={expiresChecked}
                 onChange={onExpiresChecked}
                 defaultDays={DEFAULT_EXPIRY_DAYS}
               />
+
+              <fieldset className="flex flex-col gap-5">
+                {/* A legend sits outside the fieldset's flex flow, so the
+                    gap between it and the first checkbox is set here. */}
+                <Text as="legend" size="md" weight="medium" className="mb-3">
+                  <FormattedMessage
+                    id="pages.personal_tokens.scopes_group_label"
+                    defaultMessage="Scopes"
+                    description="Label for the group of scope checkboxes in the add token dialog"
+                  />
+                </Text>
+
+                <Form.InlineField
+                  name="scope_mas_admin"
+                  control={<Form.CheckboxControl />}
+                >
+                  <Form.Label>{MAS_ADMIN_SCOPE}</Form.Label>
+                  <Form.HelpMessage>
+                    <FormattedMessage
+                      id="pages.personal_tokens.scope_mas_admin_help"
+                      defaultMessage="Access to the MAS admin API"
+                      description="Help text for MAS admin scope"
+                    />
+                  </Form.HelpMessage>
+                </Form.InlineField>
+
+                <Form.InlineField
+                  name="scope_matrix_client"
+                  control={
+                    <Form.CheckboxControl
+                      readOnly={deviceChecked || synapseAdminChecked}
+                      checked={matrixClientChecked}
+                      onChange={onMatrixClientChecked}
+                    />
+                  }
+                >
+                  <Form.Label>{MATRIX_API_SCOPE}</Form.Label>
+                  <Form.HelpMessage>
+                    <FormattedMessage
+                      id="pages.personal_tokens.scope_matrix_client_help"
+                      defaultMessage="Access to the Matrix Client-Server API"
+                      description="Help text for Matrix Client API scope"
+                    />
+                  </Form.HelpMessage>
+                </Form.InlineField>
+
+                <Form.InlineField
+                  name="scope_synapse_admin"
+                  control={
+                    <Form.CheckboxControl
+                      checked={synapseAdminChecked}
+                      onChange={onSynapseAdminChecked}
+                    />
+                  }
+                >
+                  <Form.Label>{SYNAPSE_ADMIN_SCOPE}</Form.Label>
+                  <Form.HelpMessage>
+                    <FormattedMessage
+                      id="pages.personal_tokens.scope_synapse_admin_help"
+                      defaultMessage="Access to the Synapse admin API"
+                      description="Help text for Synapse admin scope"
+                    />
+                  </Form.HelpMessage>
+                </Form.InlineField>
+
+                <Form.InlineField
+                  name="scope_device"
+                  control={
+                    <Form.CheckboxControl
+                      checked={deviceChecked}
+                      onChange={onDeviceChecked}
+                      disabled={!matrixClientChecked}
+                    />
+                  }
+                >
+                  <Form.Label>{DEVICE_SCOPE}</Form.Label>
+                  <Form.HelpMessage>
+                    <FormattedMessage
+                      id="pages.personal_tokens.scope_device_help"
+                      defaultMessage="Provision a Matrix device"
+                      description="Help text for device scope"
+                    />
+                  </Form.HelpMessage>
+                </Form.InlineField>
+
+                {deviceChecked && (
+                  <Form.Field name="device_id" serverInvalid={false}>
+                    <Form.Label>
+                      <FormattedMessage
+                        id="pages.personal_tokens.device_id_label"
+                        defaultMessage="Device ID"
+                        description="Label for device ID field"
+                      />
+                    </Form.Label>
+                    <Form.TextControl
+                      placeholder={intl.formatMessage({
+                        id: "pages.personal_tokens.device_id_placeholder",
+                        defaultMessage: "ABCDEFGHIJ",
+                        description: "Placeholder for device ID field",
+                      })}
+                    />
+                    <Form.HelpMessage>
+                      <FormattedMessage
+                        id="pages.personal_tokens.device_id_help"
+                        defaultMessage="Leave empty to generate a random 10-character device ID"
+                        description="Help text for device ID field"
+                      />
+                    </Form.HelpMessage>
+                  </Form.Field>
+                )}
+              </fieldset>
 
               <Form.Submit disabled={isPending}>
                 {isPending && <InlineSpinner />}

--- a/src/routes/_console.personal-tokens.tsx
+++ b/src/routes/_console.personal-tokens.tsx
@@ -50,6 +50,7 @@ import * as Placeholder from "@/components/placeholder";
 import { UserInfo } from "@/components/room-info";
 import * as messages from "@/messages";
 import AppFooter from "@/ui/footer";
+import { personalTokenExpiryText } from "@/ui/token-expiry";
 import { PersonalTokenStatusBadge } from "@/ui/token-status-badge";
 import { UserPicker } from "@/ui/user-picker";
 import { computeHumanReadableDateTimeStringFromUtc } from "@/utils/datetime";
@@ -781,16 +782,7 @@ function RouteComponent() {
             const token = row.original;
             return (
               <Text size="sm" className="text-text-secondary">
-                {token.attributes.expires_at
-                  ? computeHumanReadableDateTimeStringFromUtc(
-                      token.attributes.expires_at,
-                    )
-                  : intl.formatMessage({
-                      id: "pages.personal_tokens.never_expires",
-                      defaultMessage: "Never expires",
-                      description:
-                        "Text shown when a token has no expiration date",
-                    })}
+                {personalTokenExpiryText(intl, token.attributes)}
               </Text>
             );
           },

--- a/src/routes/_console.personal-tokens.tsx
+++ b/src/routes/_console.personal-tokens.tsx
@@ -50,7 +50,11 @@ import * as Placeholder from "@/components/placeholder";
 import { UserInfo } from "@/components/room-info";
 import * as messages from "@/messages";
 import AppFooter from "@/ui/footer";
-import { personalTokenExpiryText } from "@/ui/token-expiry";
+import {
+  DEFAULT_EXPIRY_DAYS,
+  TokenExpiryField,
+  personalTokenExpiryText,
+} from "@/ui/token-expiry";
 import { PersonalTokenStatusBadge } from "@/ui/token-status-badge";
 import { UserPicker } from "@/ui/user-picker";
 import { computeHumanReadableDateTimeStringFromUtc } from "@/utils/datetime";
@@ -168,6 +172,7 @@ const PersonalTokenAddButton = ({
   const [matrixClientChecked, setMatrixClientChecked] = useState(false);
   const [deviceChecked, setDeviceChecked] = useState(false);
   const [synapseAdminChecked, setSynapseAdminChecked] = useState(false);
+  const [expiresChecked, setExpiresChecked] = useState(false);
 
   const queryClient = useQueryClient();
   const intl = useIntl();
@@ -195,6 +200,13 @@ const PersonalTokenAddButton = ({
         setMatrixClientChecked(true);
       }
       return newValue;
+    },
+    [],
+  );
+
+  const onExpiresChecked = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      setExpiresChecked(event.currentTarget.checked);
     },
     [],
   );
@@ -261,7 +273,8 @@ const PersonalTokenAddButton = ({
       const formData = new FormData(event.currentTarget);
       const humanName = formData.get("human_name") as string;
       const actorUserId = formData.get("actor_user_id") as string;
-      const expiresInDays = formData.get("expires_in_days") as string;
+      // Absent unless the expiry checkbox was ticked; see `TokenExpiryField`.
+      const expiresInDays = formData.get("expires_in_days") as string | null;
 
       // Somewhat of a hack to show the input as invalid if no user is selected
       if (!actorUserId) {
@@ -287,7 +300,7 @@ const PersonalTokenAddButton = ({
         scope,
       };
 
-      if (expiresInDays && expiresInDays !== "") {
+      if (expiresInDays) {
         parameters.expires_in =
           Number.parseInt(expiresInDays, 10) * 24 * 60 * 60; // Convert days to seconds
       }
@@ -310,6 +323,7 @@ const PersonalTokenAddButton = ({
       setMatrixClientChecked(false);
       setDeviceChecked(false);
       setSynapseAdminChecked(false);
+      setExpiresChecked(false);
       setMissingActor(false);
     },
     [isPending, reset],
@@ -521,31 +535,11 @@ const PersonalTokenAddButton = ({
                 </Form.Field>
               )}
 
-              <Form.Field name="expires_in_days" serverInvalid={false}>
-                <Form.Label>
-                  <FormattedMessage
-                    id="pages.personal_tokens.expires_in_label"
-                    defaultMessage="Expires in (days)"
-                    description="Label for the expiry field"
-                  />
-                </Form.Label>
-                <Form.TextControl
-                  type="number"
-                  min="1"
-                  placeholder={intl.formatMessage({
-                    id: "pages.personal_tokens.expires_in_placeholder",
-                    defaultMessage: "30",
-                    description: "Placeholder for the expiry field",
-                  })}
-                />
-                <Form.HelpMessage>
-                  <FormattedMessage
-                    id="pages.personal_tokens.expires_in_help"
-                    defaultMessage="Leave empty for tokens that never expire"
-                    description="Help text for the expiry field"
-                  />
-                </Form.HelpMessage>
-              </Form.Field>
+              <TokenExpiryField
+                checked={expiresChecked}
+                onChange={onExpiresChecked}
+                defaultDays={DEFAULT_EXPIRY_DAYS}
+              />
 
               <Form.Submit disabled={isPending}>
                 {isPending && <InlineSpinner />}

--- a/src/ui/token-expiry.tsx
+++ b/src/ui/token-expiry.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+
+import { type IntlShape, defineMessage } from "react-intl";
+
+import type { SingleResourceForPersonalSession } from "@/api/mas/api/types.gen";
+import { computeHumanReadableDateTimeStringFromUtc } from "@/utils/datetime";
+
+const neverExpires = defineMessage({
+  id: "pages.personal_tokens.never_expires",
+  defaultMessage: "Never expires",
+  description: "Text shown when a token has no expiration date",
+});
+
+const revoked = defineMessage({
+  id: "pages.personal_tokens.expiry_revoked",
+  defaultMessage: "Revoked",
+  description: "Text shown in place of the expiry of a revoked token",
+});
+
+// MAS drops the token of a revoked session, so its `expires_at` is null like a
+// token that never expires.
+export const personalTokenExpiryText = (
+  intl: IntlShape,
+  token: SingleResourceForPersonalSession["attributes"],
+): string => {
+  if (token.revoked_at) return intl.formatMessage(revoked);
+  if (token.expires_at)
+    return computeHumanReadableDateTimeStringFromUtc(token.expires_at);
+  return intl.formatMessage(neverExpires);
+};

--- a/src/ui/token-expiry.tsx
+++ b/src/ui/token-expiry.tsx
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
-import { type IntlShape, defineMessage } from "react-intl";
+import { Form } from "@vector-im/compound-web";
+import { FormattedMessage, type IntlShape, defineMessage } from "react-intl";
 
 import type { SingleResourceForPersonalSession } from "@/api/mas/api/types.gen";
 import { computeHumanReadableDateTimeStringFromUtc } from "@/utils/datetime";
@@ -30,3 +31,90 @@ export const personalTokenExpiryText = (
     return computeHumanReadableDateTimeStringFromUtc(token.expires_at);
   return intl.formatMessage(neverExpires);
 };
+
+// Arbitrary: what the dialogs suggest when the token itself says nothing.
+export const DEFAULT_EXPIRY_DAYS = 30;
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+// Regenerating a token can only set a new duration, so a token with time left
+// is offered the days it has left rather than the duration it was created with,
+// rounded up so that regenerating never shortens it. An expiry already in the
+// past, or one nothing can parse, has no days to offer.
+export const daysUntilExpiry = (
+  expiresAt: string | null | undefined,
+): number | null => {
+  const expiry = expiresAt ? Date.parse(expiresAt) : Number.NaN;
+  if (Number.isNaN(expiry)) return null;
+  const days = Math.ceil((expiry - Date.now()) / DAY_IN_MS);
+  return days > 0 ? days : null;
+};
+
+interface TokenExpiryFieldProps {
+  checked: boolean;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  defaultDays: number;
+}
+
+// A personal session with no `expires_in` gets a token that never expires, both
+// when creating and when regenerating, so the choice is a checkbox rather than
+// an empty number field.
+export const TokenExpiryField: React.FC<TokenExpiryFieldProps> = ({
+  checked,
+  onChange,
+  defaultDays,
+}) => (
+  <>
+    <Form.InlineField
+      name="expires"
+      control={<Form.CheckboxControl checked={checked} onChange={onChange} />}
+    >
+      <Form.Label>
+        <FormattedMessage
+          id="pages.personal_tokens.set_expiry_label"
+          defaultMessage="Set an expiry"
+          description="Label for the checkbox enabling a token expiry"
+        />
+      </Form.Label>
+      <Form.HelpMessage>
+        <FormattedMessage
+          id="pages.personal_tokens.set_expiry_help"
+          defaultMessage="Otherwise the token never expires"
+          description="Help text for the checkbox enabling a token expiry"
+        />
+      </Form.HelpMessage>
+    </Form.InlineField>
+
+    {checked && (
+      <Form.Field name="expires_in_days" serverInvalid={false}>
+        <Form.Label>
+          <FormattedMessage
+            id="pages.personal_tokens.expires_in_label"
+            defaultMessage="Expires in (days)"
+            description="Label for the expiry field"
+          />
+        </Form.Label>
+        <Form.TextControl
+          type="number"
+          min="1"
+          required
+          defaultValue={defaultDays}
+        />
+        <Form.ErrorMessage match="valueMissing">
+          <FormattedMessage
+            id="pages.personal_tokens.expires_in_missing"
+            defaultMessage="Enter how many days the token should last"
+            description="Error shown when the expiry field is left empty"
+          />
+        </Form.ErrorMessage>
+        <Form.ErrorMessage match="rangeUnderflow">
+          <FormattedMessage
+            id="pages.personal_tokens.expires_in_underflow"
+            defaultMessage="A token has to last at least one day"
+            description="Error shown when the expiry field is set below one day"
+          />
+        </Form.ErrorMessage>
+      </Form.Field>
+    )}
+  </>
+);

--- a/tests/pages/tokens.spec.ts
+++ b/tests/pages/tokens.spec.ts
@@ -183,7 +183,7 @@ test.describe("personal tokens", () => {
               - paragraph: "@admin:${SERVER_NAME}"
             - gridcell "Revoked"
             - gridcell "Never used"
-            - gridcell "Never expires"
+            - gridcell "Revoked"
           - row:
             - gridcell:
               - link "Old migration script"
@@ -238,6 +238,31 @@ test.describe("personal tokens", () => {
     await expect(
       detail.getByRole("button", { name: "Regenerate token" }),
     ).toBeEnabled();
+  });
+
+  test("shows a revoked personal token's expiry as revoked", async ({
+    page,
+  }) => {
+    await loginAs(page);
+    await page.goto(
+      `/personal-tokens/${personalSessionId(DEFAULT_PERSONAL_SESSIONS, 1)}`,
+    );
+
+    // A revoked session has no token left, so MAS reports no expiry for it —
+    // which must not read as a token that never expires.
+    const detail = drawer(
+      page,
+      page.getByRole("heading", { name: "Retired bridge" }),
+    );
+
+    await expect(detail).toMatchAriaSnapshot(`
+      - listitem:
+        - term: Expires at
+        - definition: Revoked
+      - listitem:
+        - term: Revoked at
+        - definition: /2026/
+    `);
   });
 
   test("cancels revoking a personal token", async ({ page }) => {

--- a/tests/pages/tokens.spec.ts
+++ b/tests/pages/tokens.spec.ts
@@ -2,17 +2,20 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+import { http, HttpResponse } from "msw";
 
 import { drawer, heading } from "../helpers";
 import { loginAs } from "../mocks/auth";
 import { masFailingPost } from "../mocks/failing";
+import * as mas from "../mocks/mas";
 import {
   DEFAULT_PERSONAL_SESSIONS,
   DEFAULT_REGISTRATION_TOKENS,
   personalSessionId,
   registrationTokenId,
   SERVER_NAME,
+  singlePersonalSession,
   ulid,
 } from "../mocks/fixtures";
 import { expect, test } from "../mocks/test";
@@ -44,6 +47,34 @@ const expectRevokeCancelled = async (
   await expect(dialog).toBeHidden();
   await expect(detail.getByText("Active", { exact: true })).toBeVisible();
 };
+
+/**
+ * Fill the create-token dialog's mandatory fields — a name, an acting user and
+ * one scope — leaving the expiry alone.
+ */
+const fillNewToken = async (dialog: Locator, name: string): Promise<void> => {
+  await dialog.getByRole("textbox", { name: "Token name" }).fill(name);
+  await dialog.getByRole("combobox").fill("alice");
+  await dialog.getByRole("option").first().click();
+  await dialog.getByRole("checkbox", { name: "urn:mas:admin" }).check();
+};
+
+/**
+ * A personal token with ten days left to run, and the handlers serving it. The
+ * shared fixtures are deliberately clock-independent, so none of them has a
+ * future expiry, which is the only thing the regenerate dialog prefills from.
+ */
+const EXPIRING = [
+  {
+    ...DEFAULT_PERSONAL_SESSIONS[0],
+    expires_at: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
+const expiringSessionHandlers = () => [
+  mas.personalSessionsList(EXPIRING),
+  mas.personalSessionDetail(EXPIRING),
+];
 
 test.describe("registration tokens", () => {
   test("lists the mocked registration tokens", async ({ page }) => {
@@ -263,6 +294,119 @@ test.describe("personal tokens", () => {
         - term: Revoked at
         - definition: /2026/
     `);
+  });
+
+  test("asks for a day count only once an expiry is wanted", async ({
+    page,
+    network,
+  }) => {
+    let body: unknown;
+    network.use(
+      http.post("*/api/admin/v1/personal-sessions", async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json(singlePersonalSession(0), { status: 201 });
+      }),
+    );
+
+    await loginAs(page);
+    await page.goto("/personal-tokens");
+    await page.getByRole("button", { name: "Add" }).click();
+
+    const dialog = page.getByRole("dialog");
+    const days = dialog.getByRole("spinbutton", { name: "Expires in (days)" });
+    await expect(days).toBeHidden();
+
+    await fillNewToken(dialog, "Expiring token");
+    await dialog.getByRole("checkbox", { name: "Set an expiry" }).check();
+    await expect(days).toHaveValue("30");
+
+    // Radix suppresses the browser's own validation bubble, so an empty day
+    // count has to be reported in the form or the submit does nothing at all.
+    await days.fill("");
+    await dialog.getByRole("button", { name: "Create token" }).click();
+    await expect(
+      dialog.getByText("Enter how many days the token should last"),
+    ).toBeVisible();
+
+    await days.fill("30");
+    await dialog.getByRole("button", { name: "Create token" }).click();
+
+    await expect
+      .poll(() => body)
+      .toEqual(expect.objectContaining({ expires_in: 30 * 24 * 60 * 60 }));
+  });
+
+  test("offers the days a regenerated token has left", async ({
+    page,
+    network,
+  }) => {
+    network.use(...expiringSessionHandlers());
+
+    await loginAs(page);
+    await page.goto(`/personal-tokens/${personalSessionId(EXPIRING, 0)}`);
+
+    await page.getByRole("button", { name: "Regenerate token" }).click();
+    const dialog = page.getByRole("dialog");
+
+    await expect(
+      dialog.getByRole("checkbox", { name: "Set an expiry" }),
+    ).toBeChecked();
+    await expect(
+      dialog.getByRole("spinbutton", { name: "Expires in (days)" }),
+    ).toHaveValue("10");
+  });
+
+  test("forgets an abandoned expiry choice on the next regenerate", async ({
+    page,
+    network,
+  }) => {
+    network.use(...expiringSessionHandlers());
+
+    await loginAs(page);
+    await page.goto(`/personal-tokens/${personalSessionId(EXPIRING, 0)}`);
+
+    const regenerate = page.getByRole("button", { name: "Regenerate token" });
+    await regenerate.click();
+
+    const expires = page
+      .getByRole("dialog")
+      .getByRole("checkbox", { name: "Set an expiry" });
+    await expires.uncheck();
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).toBeHidden();
+
+    // Dismissing the dialog abandons the choice: reopening it starts from the
+    // token again, rather than from the never-expires the admin backed out of.
+    await regenerate.click();
+    await expect(expires).toBeChecked();
+  });
+
+  test("asks for no expiry when the checkbox is left unticked", async ({
+    page,
+    network,
+  }) => {
+    let body: unknown;
+    network.use(
+      http.post("*/api/admin/v1/personal-sessions", async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json(singlePersonalSession(0), { status: 201 });
+      }),
+    );
+
+    await loginAs(page);
+    await page.goto("/personal-tokens");
+    await page.getByRole("button", { name: "Add" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await fillNewToken(dialog, "Never expires");
+    await dialog.getByRole("button", { name: "Create token" }).click();
+
+    // MAS mints a token that never expires when the request carries no
+    // `expires_in` at all.
+    await expect
+      .poll(() => body)
+      .toEqual(expect.objectContaining({ human_name: "Never expires" }));
+    expect(body).not.toHaveProperty("expires_in");
   });
 
   test("cancels revoking a personal token", async ({ page }) => {

--- a/translations/compiled/en.json
+++ b/translations/compiled/en.json
@@ -2104,6 +2104,12 @@
       "value": "Access to the Synapse admin API"
     }
   ],
+  "pages.personal_tokens.scopes_group_label": [
+    {
+      "type": 0,
+      "value": "Scopes"
+    }
+  ],
   "pages.personal_tokens.scopes_label": [
     {
       "type": 0,

--- a/translations/compiled/en.json
+++ b/translations/compiled/en.json
@@ -1878,6 +1878,12 @@
       "value": "30"
     }
   ],
+  "pages.personal_tokens.expiry_revoked": [
+    {
+      "type": 0,
+      "value": "Revoked"
+    }
+  ],
   "pages.personal_tokens.filter.active": [
     {
       "type": 0,

--- a/translations/compiled/en.json
+++ b/translations/compiled/en.json
@@ -1860,22 +1860,22 @@
       "value": "Expires at"
     }
   ],
-  "pages.personal_tokens.expires_in_help": [
-    {
-      "type": 0,
-      "value": "Leave empty for tokens that never expire"
-    }
-  ],
   "pages.personal_tokens.expires_in_label": [
     {
       "type": 0,
       "value": "Expires in (days)"
     }
   ],
-  "pages.personal_tokens.expires_in_placeholder": [
+  "pages.personal_tokens.expires_in_missing": [
     {
       "type": 0,
-      "value": "30"
+      "value": "Enter how many days the token should last"
+    }
+  ],
+  "pages.personal_tokens.expires_in_underflow": [
+    {
+      "type": 0,
+      "value": "A token has to last at least one day"
     }
   ],
   "pages.personal_tokens.expiry_revoked": [
@@ -2010,12 +2010,6 @@
       "value": "Failed to regenerate personal token"
     }
   ],
-  "pages.personal_tokens.regenerate_expires_help": [
-    {
-      "type": 0,
-      "value": "Leave empty to keep the same expiry as before, or set a new expiry time"
-    }
-  ],
   "pages.personal_tokens.regenerate_success": [
     {
       "type": 0,
@@ -2114,6 +2108,18 @@
     {
       "type": 0,
       "value": "Scopes"
+    }
+  ],
+  "pages.personal_tokens.set_expiry_help": [
+    {
+      "type": 0,
+      "value": "Otherwise the token never expires"
+    }
+  ],
+  "pages.personal_tokens.set_expiry_label": [
+    {
+      "type": 0,
+      "value": "Set an expiry"
     }
   ],
   "pages.personal_tokens.status.active": [

--- a/translations/extracted/en.json
+++ b/translations/extracted/en.json
@@ -1011,6 +1011,10 @@
     "description": "Help text for Synapse admin scope",
     "message": "Access to the Synapse admin API"
   },
+  "pages.personal_tokens.scopes_group_label": {
+    "description": "Label for the group of scope checkboxes in the add token dialog",
+    "message": "Scopes"
+  },
   "pages.personal_tokens.scopes_label": {
     "description": "Label for the scopes field",
     "message": "Scopes"

--- a/translations/extracted/en.json
+++ b/translations/extracted/en.json
@@ -851,17 +851,17 @@
     "description": "Label for the token expiration date field",
     "message": "Expires at"
   },
-  "pages.personal_tokens.expires_in_help": {
-    "description": "Help text for the expiry field",
-    "message": "Leave empty for tokens that never expire"
-  },
   "pages.personal_tokens.expires_in_label": {
     "description": "Label for the expiry field",
     "message": "Expires in (days)"
   },
-  "pages.personal_tokens.expires_in_placeholder": {
-    "description": "Placeholder for the expiry field",
-    "message": "30"
+  "pages.personal_tokens.expires_in_missing": {
+    "description": "Error shown when the expiry field is left empty",
+    "message": "Enter how many days the token should last"
+  },
+  "pages.personal_tokens.expires_in_underflow": {
+    "description": "Error shown when the expiry field is set below one day",
+    "message": "A token has to last at least one day"
   },
   "pages.personal_tokens.expiry_revoked": {
     "description": "Text shown in place of the expiry of a revoked token",
@@ -951,10 +951,6 @@
     "description": "Error message when regenerating a personal token fails",
     "message": "Failed to regenerate personal token"
   },
-  "pages.personal_tokens.regenerate_expires_help": {
-    "description": "Help text for the expiry field when regenerating",
-    "message": "Leave empty to keep the same expiry as before, or set a new expiry time"
-  },
   "pages.personal_tokens.regenerate_success": {
     "description": "Success message when a personal token is regenerated",
     "message": "Personal token regenerated successfully"
@@ -1018,6 +1014,14 @@
   "pages.personal_tokens.scopes_label": {
     "description": "Label for the scopes field",
     "message": "Scopes"
+  },
+  "pages.personal_tokens.set_expiry_help": {
+    "description": "Help text for the checkbox enabling a token expiry",
+    "message": "Otherwise the token never expires"
+  },
+  "pages.personal_tokens.set_expiry_label": {
+    "description": "Label for the checkbox enabling a token expiry",
+    "message": "Set an expiry"
   },
   "pages.personal_tokens.status.active": {
     "description": "Status badge for active personal tokens",

--- a/translations/extracted/en.json
+++ b/translations/extracted/en.json
@@ -863,6 +863,10 @@
     "description": "Placeholder for the expiry field",
     "message": "30"
   },
+  "pages.personal_tokens.expiry_revoked": {
+    "description": "Text shown in place of the expiry of a revoked token",
+    "message": "Revoked"
+  },
   "pages.personal_tokens.filter.active": {
     "description": "Filter label for active personal tokens",
     "message": "Active"


### PR DESCRIPTION
Revoked personal tokens showed "Never expires". MAS drops the access token of a revoked session, so `expires_at` comes back null, the same as a token created without an expiry. The list and the drawer now say "Revoked".

The expiry field's "30" was a placeholder the form never applied: leaving it empty creates a token that never expires, on regenerate too, whatever the help text there claimed. Both dialogs now ask with a checkbox and fill in the day count when you tick it, 30 when creating and the days left when regenerating.

The expiry sits above the scope checkboxes instead of under them, where it read as a fifth permission, and the scopes have a legend.

Fixes #630
Fixes #603